### PR TITLE
refactor: shift activity assessment language from understanding to mastery

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "1111 Learn",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An agentic learning app by 11:11 Philosopher's Group.",
   "permissions": [
     "sidePanel",

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -4,20 +4,20 @@ Evaluate a learner's draft submission by looking at their screenshot.
 
 ## Assessment philosophy
 
-Assess whether the learner demonstrated UNDERSTANDING of the topic, not whether they wrote specific words or followed a template. The learner chooses their own content — your job is to evaluate whether that content shows genuine comprehension. If the learner took a different approach than expected but clearly understands the material, that's a strength, not a weakness. Improvements should point the learner toward deeper understanding, not toward specific content you want to see.
+Assess whether the learner demonstrated MASTERY of the objective, not whether they wrote specific words or followed a template (unless those specific words or templates are part of the objective). The learner chooses their own content — your job is to evaluate whether that content shows genuine mastery. If the learner took a different approach than expected but clearly demonstrates mastery of the material, that's a strength, not a weakness. Improvements should point the learner toward deeper mastery, not toward specific content you want to see.
 
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person.
 - Write in plain, simple language. Short sentences. No jargon.
-- Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
-- Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.
+- Feedback: 1-2 sentences about what you see and whether it demonstrates mastery of the objective.
+- Strengths: 1-3 bullet points, one sentence each. Focus on evidence of mastery.
 - Improvements: 1-3 bullet points, one sentence each. Suggest areas to explore deeper or misconceptions to address — never dictate specific content to add.
-- Score: 0.0 to 1.0 based on how well the work demonstrates understanding of the goal.
+- Score: 0.0 to 1.0 based on how well the work demonstrates mastery of the objective.
 - Recommendation:
-  - "advance" -- work shows solid understanding, move on
-  - "revise" -- shows gaps in understanding that need addressing
-  - "continue" -- shows basic understanding but could go deeper
+  - "advance" -- work shows solid mastery, move on
+  - "revise" -- shows gaps in mastery that need addressing
+  - "continue" -- shows basic mastery but could go deeper
 - Set "passed" to true if this is a final activity and score >= 0.7, or if non-final and you recommend "advance" or "continue".
 - For revisions, briefly note what improved.
 


### PR DESCRIPTION
Apply Stefin's feedback on #issue-11: replace "understanding"/"comprehension" with "mastery" throughout activity-assessment.md, update first sentence to reference the objective, and clarify that specific words/templates are valid criteria when part of the objective.

Closes #11

Generated with [Claude Code](https://claude.ai/code)