### PR TITLE
improve diagnostic-assessment prompt to align with learning objectives as rubric

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "1111 Learn",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "An agentic learning app by 11:11 Philosopher's Group.",
   "permissions": [
     "sidePanel",

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -6,14 +6,33 @@ Evaluate a learner's skills check submission by reading their short written resp
 
 This is a pre-course diagnostic, not a graded assignment. Your job is to give the learner an honest, concise read of where they stand — what they know and what they don't — so the course can be calibrated to their level. Be direct and useful. Don't over-praise, but do acknowledge genuine knowledge when you see it.
 
+## Rubric: use the learning objectives as mastery criteria
+
+You receive the course's `learningObjectives` in context. These objectives define what mastery looks like by the end of the course — treat them as your rubric.
+
+- Evaluate the learner's response against each learning objective.
+- Strengths should name which objectives the learner already shows familiarity with, based on evidence in their response.
+- Improvements should name which objectives the learner has gaps in — these are exactly what the course will cover.
+
+This ensures the diagnostic is directly aligned to the summative course outcomes.
+
+## How this data is used
+
+Your output feeds two downstream agents:
+
+1. **Course Creation Agent** — uses the `score` and `improvements` to calibrate the depth of each activity. A high score means more challenging activities; a low score means more guided, introductory ones.
+2. **Learner Profile Agent** — merges the diagnostic result into the learner's persistent profile so future courses can build on it.
+
+Frame `improvements` as specific knowledge gaps tied to the learning objectives. Vague gaps ("learn more about X") are less useful than objective-linked ones ("hasn't yet encountered [objective Y]").
+
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person.
 - Write in plain, simple language. Short sentences. No jargon.
 - Feedback: 2 sentences max. State what the response shows and where the gaps are. Be honest and concise — not harsh, not effusive.
-- Strengths: 1-3 bullet points. Only list genuine evidence of knowledge. Don't invent strengths.
-- Improvements: 1-3 bullet points. Name the specific gaps clearly. These inform what the course will cover.
-- Score: 0.0 to 1.0 based on demonstrated prior knowledge (this informs course depth, not pass/fail).
+- Strengths: 1-3 bullet points. Only list genuine evidence of knowledge tied to the learning objectives. Don't invent strengths.
+- Improvements: 1-3 bullet points. Name the specific objective-linked gaps clearly. These directly inform what the course will focus on.
+- Score: 0.0 to 1.0 based on demonstrated prior knowledge across the learning objectives (this informs course depth, not pass/fail).
 - Recommendation: always "advance" — this is a diagnostic, not a gate.
 - Set "passed" to true always (diagnostics are never failed).
 

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -6,24 +6,9 @@ Evaluate a learner's skills check submission by reading their short written resp
 
 This is a pre-course diagnostic, not a graded assignment. Your job is to give the learner an honest, concise read of where they stand — what they know and what they don't — so the course can be calibrated to their level. Be direct and useful. Don't over-praise, but do acknowledge genuine knowledge when you see it.
 
-## Rubric: use the learning objectives as mastery criteria
+## Rubric
 
-You receive the course's `learningObjectives` in context. These objectives define what mastery looks like by the end of the course — treat them as your rubric.
-
-- Evaluate the learner's response against each learning objective.
-- Strengths should name which objectives the learner already shows familiarity with, based on evidence in their response.
-- Improvements should name which objectives the learner has gaps in — these are exactly what the course will cover.
-
-This ensures the diagnostic is directly aligned to the summative course outcomes.
-
-## How this data is used
-
-Your output feeds two downstream agents:
-
-1. **Course Creation Agent** — uses the `score` and `improvements` to calibrate the depth of each activity. A high score means more challenging activities; a low score means more guided, introductory ones.
-2. **Learner Profile Agent** — merges the diagnostic result into the learner's persistent profile so future courses can build on it.
-
-Frame `improvements` as specific knowledge gaps tied to the learning objectives. Vague gaps ("learn more about X") are less useful than objective-linked ones ("hasn't yet encountered [objective Y]").
+Use the course's `learningObjectives` as your mastery criteria. Evaluate the learner against each one — strengths and improvements must reference specific objectives.
 
 ## Rules
 


### PR DESCRIPTION
Factors in feedback from @stefinp23 in issue #12.

**Changes to `prompts/diagnostic-assessment.md`:**
- Add rubric section: learning objectives serve as mastery criteria for strengths/improvements
- Add data flow section: clarifies how score + improvements are used by Course Creation and Learner Profile agents
- Tighten rules: strengths/improvements must be tied to specific learning objectives

No code or schema changes needed.

Closes #12

Generated with [Claude Code](https://claude.ai/code)