### PR TITLE
Assessment-backward learning architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,49 @@
 # CLAUDE.md -- 1111 Learn
 
 ## Project overview
-1111 Learn is a Chrome extension (Manifest V3, side panel) that helps learners build their professional portfolio through AI-guided courses. Nine AI agents powered by the Claude API drive the experience. Courses contain units; each unit has a diagnostic (skills check) and a sequence of activities. The user provides their own Anthropic API key via a first-run onboarding wizard, or logs in to use a managed account. All structured data is stored locally in SQLite (via sql.js WASM), persisted to `chrome.storage.local` as a serialized database. Binary assets (screenshots) remain in IndexedDB, referenced by key. When logged in, the server is the source of truth and local storage acts as a read cache.
+1111 Learn is a Chrome extension (Manifest V3, side panel) that helps learners build their professional portfolio through AI-guided courses. Nine AI agents powered by the Claude API drive an assessment-backward learning experience. A summative assessment is generated first from course learning objectives (with rubric, exemplar, and multi-step capture task). The learner takes it as a diagnostic baseline, a gap analysis drives personalized formative activities, and the learner retakes the summative to demonstrate mastery. The user provides their own Anthropic API key via a first-run onboarding wizard, or logs in to use a managed account. All structured data is stored locally in SQLite (via sql.js WASM), persisted to `chrome.storage.local` as a serialized database. Binary assets (screenshots) remain in IndexedDB, referenced by key. When logged in, the server is the source of truth and local storage acts as a read cache.
 
 ## Architecture
 Nine agents drive the learning experience:
 - **Onboarding Conversation Agent** (`MODEL_LIGHT`) -- multi-turn chat that gets to know the learner and builds their initial profile
 - **Onboarding Profile Agent** (`MODEL_LIGHT`) -- creates an initial learner profile (fallback when conversation is skipped)
-- **Diagnostic Conversation Agent** (`MODEL_LIGHT`) -- opens and drives the skills check conversation; receives the learner profile, unit objectives, and course scope to calibrate depth; for optional units where the profile shows familiarity, can complete the assessment immediately without asking questions
-- **Diagnostic Assessment Agent** (`MODEL_LIGHT`) -- evaluates learner text responses during the diagnostic and re-evaluates on dispute
-- **Course Creation Agent** (`MODEL_LIGHT`) -- generates a personalized learning plan skeleton, informed by the diagnostic result
-- **Activity Creation Agent** (`MODEL_LIGHT`) -- fills in one activity at a time as the learner reaches it
-- **Activity Assessment Agent** (`MODEL_HEAVY` + vision) -- evaluates screenshots of learner work
+- **Summative Generation Agent** (`MODEL_LIGHT`) -- generates the summative assessment (multi-step capture task + rubric + exemplar) from all course learning objectives
+- **Summative Rubric Review Agent** (`MODEL_LIGHT`) -- multi-turn conversation about the rubric/exemplar; can trigger summative regeneration based on learner feedback
+- **Summative Assessment Agent** (`MODEL_HEAVY` + vision) -- scores multiple screenshots against rubric criteria; enforces ratchet rule (scores only go up)
+- **Gap Analysis Agent** (`MODEL_LIGHT`) -- analyzes baseline summative attempt to identify per-criterion gaps and priorities
+- **Journey Generation Agent** (`MODEL_LIGHT`) -- selects, orders, and sizes predefined units with formative activities mapped to rubric criteria
+- **Activity Creation Agent** (`MODEL_LIGHT`) -- generates one formative activity at a time, targeting specific rubric criteria
+- **Activity Assessment Agent** (`MODEL_HEAVY` + vision) -- evaluates screenshots of learner work with optional rubric-criteria scoring
 - **Activity Q&A Agent** (`MODEL_LIGHT`) -- answers learner questions about activities and assessments inline
-- **Learner Profile Agent** (`MODEL_LIGHT`) -- incrementally updates the learner profile after assessments, diagnostic results, and learner feedback
+- **Learner Profile Agent** (`MODEL_LIGHT`) -- incrementally updates the learner profile after summative attempts, formative assessments, and learner feedback
 
 Agent prompts live in `prompts/*.md` and can be edited independently of code. The `orchestrator.converse()` function supports multi-turn conversations; `orchestrator.chatWithContext()` supports one-off Q&A with inline system prompts.
 
 ### Output validation
-All activity, assessment, and course plan outputs pass through deterministic validators in `js/validators.js` (imported by `js/orchestrator.js`) before reaching the user. Activities are checked for: ending with "Capture", max 4 steps, no platform-specific shortcuts, no multi-site instructions, no non-browser apps, viewport-sized output, and content safety. Course plans are validated for: activity count matching learning objective count exactly, no consecutive duplicate activity types, last activity being type "final", and required fields. Assessments are checked for valid score/recommendation/fields and safety. On failure, the agent call is retried once automatically.
+All agent outputs pass through deterministic validators in `js/validators.js` (imported by `js/orchestrator.js`) before reaching the user. Activities are checked for: ending with "Capture", max 4 steps, no platform-specific shortcuts, no multi-site instructions, no non-browser apps, viewport-sized output, and content safety. Summatives are validated for: task with steps array, rubric with criteria (each having 4 mastery levels), and exemplar. Summative assessments enforce the ratchet rule (no criterion score lower than prior attempt). Gap analyses are validated for criterion/level/priority structure. Journeys are validated for: valid unit IDs, activities with types/goals/rubricCriteria. Formative assessments are checked for valid score/recommendation/fields and safety. On failure, the agent call is retried once automatically.
 
 ### Onboarding
 On first run, a full-screen onboarding wizard (with animated geometric background) presents: login or continue → name → API key → "about you" conversation. The header and nav are hidden during onboarding to prevent users from navigating away. The "about you" step is a multi-turn chat: the Onboarding Conversation Agent asks follow-up questions until it has a good picture of the learner, then creates their profile. The user can skip at any time. Conversation state is persisted to the SQLite `pending_state` table so it survives panel reload. Completion is tracked via an `onboardingComplete` flag in the `settings` table. If the user is already logged in on startup, onboarding is skipped entirely and the flag is stamped automatically. In development, `.env.js` seeds the key into storage but onboarding still runs.
 
-### Diagnostic skills check
-Before every new unit, the Diagnostic Conversation Agent opens a skills check inside the unit chat. It receives the unit objectives, the learner profile, and the course scope (required/optional, sibling units). For optional units where the profile already covers the material, the agent can complete the assessment immediately (setting `done: true` in its first message) and suggest a more valuable unit. For required units, it asks 2-3 follow-up questions to gauge depth. The result is passed to the Course Creation Agent to adjust activity depth (not count -- activity count is always locked to one per learning objective). The user can skip the diagnostic at any time. During the diagnostic, conversation state is persisted to the SQLite `pending_state` table. Once the course plan is created, the diagnostic conversation (instruction, messages, and result) is saved into the `progress.diagnostic` field of the unit progress object so it remains visible in the chat history.
+### Assessment-backward design
+The entire learning journey is designed backward from a summative assessment. The flow per course is:
+1. **Summative setup**: The Summative Generation Agent creates a multi-step capture task, rubric (one criterion per objective group, each with 4 mastery levels), and exemplar from all course learning objectives.
+2. **Rubric review**: The learner reviews the rubric/exemplar in a conversation with the Summative Rubric Review Agent. They can request changes (which triggers regeneration) or skip.
+3. **Baseline attempt**: The learner attempts the summative — each step produces a screenshot capture. The Summative Assessment Agent scores all screenshots against the rubric, producing per-criterion scores.
+4. **Gap analysis + journey**: The Gap Analysis Agent identifies per-criterion gaps. The Journey Generation Agent selects, orders, and sizes predefined units with formative activities mapped to rubric criteria.
+5. **Formative learning**: The learner works through formative activities in each unit (same capture-based flow as before). Each formative targets specific rubric criteria.
+6. **Summative retake**: The learner retakes the summative. Scores can only go up (ratchet rule). If mastery is achieved, the course is complete. If not, remediation formative activities are generated for weak criteria, and the cycle repeats.
+
+The UnitsList page (`src/pages/UnitsList.jsx`) serves as the course hub, managing all summative phases. The UnitChat page handles formative activities within units.
 
 ### Conversational UX
-The entire course experience — diagnostic, course setup, activities, assessments — happens in a single chat interface per course. All loading states appear as in-chat thinking indicators (not full-screen spinners). The course header and compose bar are fixed (top and bottom); the chat scrolls between them. Users can ask questions about any activity or assessment at any time via the compose bar, powered by the Activity Q&A Agent. Q&A messages are persisted in `activity.messages[]` (each with `role`, `content`, `timestamp`) so they survive panel reloads and appear in the correct chronological position in the chat history alongside drafts and feedback. Completed activities remain visible above the current activity in the chat, creating a full scrollable history of the course. The Q&A agent receives the learner's name, profile summary, and full conversation history for context.
+Formative activities happen in a chat interface per unit. All loading states appear as in-chat thinking indicators (not full-screen spinners). The course header and compose bar are fixed (top and bottom); the chat scrolls between them. Users can ask questions about any activity or assessment at any time via the compose bar, powered by the Activity Q&A Agent. Q&A messages are persisted in `activity.messages[]` (each with `role`, `content`, `timestamp`) so they survive panel reloads and appear in the correct chronological position in the chat history alongside drafts and feedback. Completed activities remain visible above the current activity in the chat.
 
 ### Learner profile updates
-The profile updates after assessments, diagnostic results, learner feedback, and course completion. All updates run through a sequential queue in `src/lib/profileQueue.js` to prevent concurrent updates from overwriting each other. `ensureProfileExists()` guarantees a profile exists before any update. On course completion, `updateProfileOnUnitCompletion()` sends the full course context (objectives, per-activity scores) so the profile reflects all skills learned. A code-level `mergeProfile()` in `src/lib/profileQueue.js` unions array fields and merges preferences so agent responses can never accidentally lose accumulated data.
+The profile updates after summative attempts, formative assessments, learner feedback, and course mastery. All updates run through a sequential queue in `src/lib/profileQueue.js` to prevent concurrent updates from overwriting each other. `ensureProfileExists()` guarantees a profile exists before any update. On summative mastery, `updateProfileOnMasteryInBackground()` sends the full course context so the profile reflects all skills demonstrated. A code-level `mergeProfile()` in `src/lib/profileQueue.js` unions array fields (`completedUnits`, `masteredCourses`), merges preferences and `rubricProgress` (per-course per-criterion levels) so agent responses can never accidentally lose accumulated data.
 
 ### Storage (SQLite)
-All structured data is stored in an in-memory SQLite database powered by sql.js (WASM). The database is serialized to a `Uint8Array` and persisted to `chrome.storage.local` under `_sqliteDb` (debounced, plus on `visibilitychange`). `js/db.js` manages initialization, schema creation, and persistence. `js/storage.js` provides the query API used by the rest of the app — same function signatures as the original chrome.storage.local implementation. Screenshots remain in IndexedDB (`1111-blobs` store), referenced by `screenshot_key` in the `drafts` table. The schema normalizes data into proper relational tables: `units`, `conversations`, `messages`, `activities`, `drafts`, `diagnostics`, `learning_plans`, `profile`, `preferences`, `work_products`, etc. Activity IDs are scoped to their unit in the DB (`unitId::activityId`) to prevent cross-unit collisions, and stripped back to the original ID when read.
+All structured data is stored in an in-memory SQLite database powered by sql.js (WASM). The database is serialized to a `Uint8Array` and persisted to `chrome.storage.local` under `_sqliteDb` (debounced, plus on `visibilitychange`). `js/db.js` manages initialization, schema creation, persistence, and column migrations (via try/catch ALTER TABLE). `js/storage.js` provides the query API used by the rest of the app. Screenshots remain in IndexedDB (`1111-blobs` store), referenced by `screenshot_key` in the `drafts` table. The schema normalizes data into proper relational tables: `summatives`, `summative_attempts`, `gap_analysis`, `journeys`, `units`, `conversations`, `messages`, `activities`, `drafts`, `profile`, `preferences`, `work_products`, etc. Activity IDs are scoped to their unit in the DB (`unitId::activityId`) to prevent cross-unit collisions, and stripped back to the original ID when read. Units have `journey_order` and `rubric_criteria` columns; activities have `rubric_criteria`; drafts have `rubric_criteria_scores`.
 
 ### Cloud sync
 Optional login via `learn-service` (separate repo) enables cross-device data persistence. Login is never required -- the extension works fully offline/locally. When logged in, the server is the source of truth: data is written to the server after every local save, and pulled from the server on startup/login. Local storage acts as a read cache for fast access.
@@ -46,7 +56,7 @@ Optional login via `learn-service` (separate repo) enables cross-device data per
 - **Settings UI:** When signed out, the Personalization section shows a name field and the AI Provider section shows the API key input. When signed in, Personalization is hidden (name comes from the service) and the API key section shows a note that AI is provided by the 1111 Learn account. Sign Out is in the header user dropdown, not the Settings page.
 
 ## Content hierarchy
-Courses → Units → Diagnostic + Activities. `data/courses.json` defines courses, each containing a `units` array. Each unit has a `unitId`, `learningObjectives` that drive activity generation, and an optional `dependsOn` prerequisite (referencing another unit's `unitId`). Progress is tracked per unit in the SQLite `units` table (with related data in `activities`, `conversations`, `messages`, `drafts`, `diagnostics`, `learning_plans`) and synced as `unit:{unitId}`. `js/courses.js` provides `flattenCourses()` to extract all playable units into a flat list stored in `state.units`.
+Courses → Summative Assessment → Units → Formative Activities. `data/courses.json` defines courses, each containing a `units` array. Each unit has a `unitId`, `learningObjectives`, and an optional `dependsOn` prerequisite. The summative assessment is generated per course from all learning objectives. The journey generation agent selects, orders, and sizes units (hybrid: predefined in `courses.json` but journey can skip/reorder/adjust activity count). Course-level data is stored in `summatives`, `summative_attempts`, `gap_analysis`, and `journeys` tables (synced as `summative:{courseId}`, `summative-attempts:{courseId}`, `gap:{courseId}`, `journey:{courseId}`). Unit-level progress is tracked in `units`, `activities`, `drafts` tables (synced as `progress:{unitId}`). `js/courses.js` provides `flattenCourses()` to extract all playable units.
 
 ## Key conventions
 - The UI is a React app (React 18, React Router, Vite). Source lives in `src/` — pages, components, contexts, hooks, lib modules.
@@ -60,7 +70,7 @@ Courses → Units → Diagnostic + Activities. `data/courses.json` defines cours
 - All activities end with "Hit Capture to capture your screen."
 - Keyboard shortcuts: Enter submits single-line inputs, Cmd/Ctrl+Enter submits textareas, Escape dismisses dialogs.
 - URLs in activity instructions are automatically linkified.
-- Views: `onboarding`, `courses`, `units` (units within a course group), `course` (includes diagnostic + activities in one chat), `work` (portfolio cards), `work-detail` (build timeline), `settings`.
+- Views: `onboarding`, `courses`, `units` (course hub: summative phases + unit cards), `unit` (formative activities chat), `work` (course-level portfolio cards), `work-detail` (summative + formative timeline), `settings`.
 - Activity types map to user labels: `explore`→Research, `apply`→Practice, `create`→Draft, `final`→Deliver.
 - Work section shows portfolio cards with segmented progress bars; tapping opens a Build Detail view with full draft timeline and on-demand screenshot loading from IndexedDB.
 - Completion summary card shows stats (steps, captures, elapsed time) when a course finishes. Time is displayed as minutes, hours, or days depending on duration.
@@ -129,9 +139,9 @@ src/                     React app
   lib/
     syncDebounce.js       Debounced cloud sync
     profileQueue.js       Sequential profile update queue + merge logic
-    unitEngine.js         Async unit lifecycle (diagnostic, plan, activity, recording, dispute, Q&A)
+    unitEngine.js         Course + unit lifecycle (summative, gap, journey, formative activities, capture, dispute, Q&A)
     helpers.js            esc, renderMd, linkify, formatDuration
-    constants.js          TYPE_LABELS, TYPE_LETTERS, VIEW_DEPTH
+    constants.js          TYPE_LABELS, TYPE_LETTERS, VIEW_DEPTH, COURSE_PHASES, MASTERY_LEVELS
     confetti.js           Confetti animation
   components/
     AppShell.jsx          Header + nav + main wrapper + transitions
@@ -148,16 +158,19 @@ src/                     React app
       ThinkingSpinner.jsx Inline loading indicator
       UserMessage.jsx     User chat bubble
       AssistantMessage.jsx AI response with markdown
-      InstructionMessage.jsx Activity steps + linkified URLs
+      InstructionMessage.jsx Activity steps + linkified URLs + rubric criteria badges
       DraftMessage.jsx    Draft captured indicator
-      FeedbackCard.jsx    Score, strengths/improvements, actions
+      FeedbackCard.jsx    Score, strengths/improvements, rubric criteria scores, actions
       CompletionSummary.jsx Stats + confetti trigger
+      SummativeCard.jsx   Summative task, exemplar, rubric display with expandable criteria
+      RubricFeedback.jsx  Per-criterion score display with mastery level indicators
+      CaptureStep.jsx     Multi-step summative capture UI
   pages/
-    CoursesList.jsx       Course group cards
-    UnitsList.jsx         Units within a course
-    UnitChat.jsx          Full chat: diagnostic + activities + drafts + Q&A
-    Portfolio.jsx         Work product cards
-    PortfolioDetail.jsx   Build timeline
+    CoursesList.jsx       Course cards with phase status
+    UnitsList.jsx         Course hub: summative phases + unit cards in journey order
+    UnitChat.jsx          Formative activities chat: instruction + capture + assess + Q&A
+    Portfolio.jsx         Course-level portfolio cards
+    PortfolioDetail.jsx   Course portfolio: summative attempts + formative build timeline
     Settings.jsx          API key, name, profile feedback
     onboarding/
       OnboardingFlow.jsx  4-step wizard with canvas backdrop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,21 +21,23 @@ Thank you for your interest in contributing. This project is maintained by [11:1
 
 ## Architecture
 
-The app uses nine AI agents orchestrated through `js/orchestrator.js`:
+The app uses an assessment-backward design with AI agents orchestrated through `js/orchestrator.js`:
 
-1. **Onboarding Conversation Agent** -- multi-turn chat that gets to know the learner and builds their initial profile
+1. **Onboarding Conversation Agent** -- multi-turn chat that gets to know the learner
 2. **Onboarding Profile Agent** -- creates an initial learner profile (fallback when conversation is skipped)
-3. **Diagnostic Agent** -- generates a skills check question before every new course
-4. **Diagnostic Conversation Agent** -- multi-turn chat that assesses prior knowledge through follow-up questions
-5. **Course Creation Agent** -- generates a learning plan skeleton, informed by the diagnostic result
-6. **Activity Creation Agent** -- generates detailed instructions per activity
-7. **Activity Assessment Agent** -- evaluates screenshots with vision
-8. **Activity Q&A Agent** -- answers learner questions about activities and assessments inline
-9. **Learner Profile Agent** -- tracks learner progress, patterns, and preferences; updated after assessments, diagnostics, feedback, and course completion
+3. **Summative Generation Agent** -- generates a summative assessment (multi-step capture task + rubric + exemplar) from all course learning objectives
+4. **Summative Rubric Review Agent** -- multi-turn conversation about the rubric/exemplar; can trigger regeneration
+5. **Summative Assessment Agent** -- scores multi-capture screenshots against rubric criteria with ratchet rule (scores only go up)
+6. **Gap Analysis Agent** -- identifies per-criterion gaps from baseline attempt
+7. **Journey Generation Agent** -- selects, orders, and sizes units with formative activities mapped to rubric criteria
+8. **Activity Creation Agent** -- generates formative activity instructions targeting specific rubric criteria
+9. **Activity Assessment Agent** -- evaluates screenshots with optional rubric-criteria scoring
+10. **Activity Q&A Agent** -- answers learner questions inline
+11. **Learner Profile Agent** -- tracks progress after summative attempts, assessments, feedback, and mastery
 
-The entire course experience (diagnostic, setup, activities, assessments) happens in a single conversational chat interface. Multi-turn conversations use `orchestrator.converse()` with prompts in `prompts/`. One-off Q&A uses `orchestrator.chatWithContext()` with inline system prompts.
+The course experience has two layers: the course hub (UnitsList) manages summative phases, and unit chats handle formative activities. Multi-turn conversations use `orchestrator.converse()` with prompts in `prompts/`. One-off Q&A uses `orchestrator.chatWithContext()` with inline system prompts.
 
-All activity, assessment, and course plan outputs pass through deterministic validators before reaching the user. Validators check for format compliance, safety, and constraints (browser-only, single page, viewport-sized output, ends with "Capture"). Course plans are validated for activity count matching learning objective count exactly, no consecutive duplicate activity types, and required fields.
+All agent outputs pass through deterministic validators. Summatives are validated for task/rubric/exemplar structure. Summative assessments enforce the ratchet rule. Journeys are validated for unit/activity/criteria structure. Activities are validated for browser constraints.
 
 See `js/api.js` for the API client and model constants.
 
@@ -48,7 +50,7 @@ Activities must:
 - Not reference desktop apps, terminals, or file system operations
 - Not use platform-specific keyboard shortcuts
 - Take 5 minutes or less
-- Map 1:1 to learning objectives (one activity per objective, enforced by `validatePlan()`)
+- Target specific rubric criteria (formative activities are generated from gap analysis)
 - Use a different activity type from the previous activity (no two consecutive explore, apply, etc.)
 
 ## Guidelines

--- a/js/api.js
+++ b/js/api.js
@@ -30,8 +30,10 @@ export async function parseResponse(resp) {
     try { body = await resp.json(); } catch { body = {}; }
     const msg = body?.error?.message || body?.error || `API returned ${status}`;
 
-    if (status === 401) throw new ApiError('invalid_key', 'Invalid API key. Check your key in Settings.');
-    if (status === 429) throw new ApiError('rate_limit', 'Rate limited. Try again in a moment.');
+    if (status === 401) throw new ApiError('invalid_key', 'Invalid API key. Check your key in Settings.', status);
+    if (status === 429) throw new ApiError('rate_limit', 'Rate limited. Try again in a moment.', status);
+    if (status === 503 || status === 529) throw new ApiError('overloaded', 'API is temporarily overloaded. Retrying...', status);
+    if (status === 500) throw new ApiError('api', 'Internal server error. This may be a temporary issue.', status);
     throw new ApiError('api', msg, status);
   }
 

--- a/js/db.js
+++ b/js/db.js
@@ -60,12 +60,46 @@ CREATE TABLE IF NOT EXISTS units (
   final_work_product_url TEXT
 );
 
-CREATE TABLE IF NOT EXISTS learning_plans (
-  unit_id TEXT PRIMARY KEY REFERENCES units(unit_id),
-  final_work_product_description TEXT,
-  work_product_tool TEXT,
-  data TEXT,
+CREATE TABLE IF NOT EXISTS summatives (
+  course_id TEXT PRIMARY KEY,
+  task TEXT NOT NULL,
+  rubric TEXT NOT NULL,
+  exemplar TEXT NOT NULL,
+  tool TEXT,
+  estimated_time INTEGER,
+  personalized INTEGER DEFAULT 0,
+  conversation_id TEXT,
   created_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS summative_attempts (
+  id TEXT PRIMARY KEY,
+  course_id TEXT NOT NULL,
+  attempt_number INTEGER NOT NULL,
+  screenshots TEXT,
+  criteria_scores TEXT,
+  overall_score REAL,
+  mastery INTEGER DEFAULT 0,
+  feedback TEXT,
+  next_steps TEXT,
+  is_baseline INTEGER DEFAULT 0,
+  timestamp INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS gap_analysis (
+  course_id TEXT PRIMARY KEY,
+  gaps TEXT NOT NULL,
+  suggested_focus TEXT,
+  created_at INTEGER,
+  updated_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS journeys (
+  course_id TEXT PRIMARY KEY,
+  plan TEXT NOT NULL,
+  phase TEXT DEFAULT 'summative_setup',
+  created_at INTEGER,
+  updated_at INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS conversations (
@@ -97,18 +131,8 @@ CREATE TABLE IF NOT EXISTS activities (
   conversation_id TEXT REFERENCES conversations(id)
 );
 
-CREATE TABLE IF NOT EXISTS diagnostics (
-  unit_id TEXT PRIMARY KEY REFERENCES units(unit_id),
-  conversation_id TEXT REFERENCES conversations(id),
-  instruction TEXT,
-  score REAL,
-  feedback TEXT,
-  strengths TEXT,
-  improvements TEXT,
-  recommendation TEXT,
-  passed INTEGER,
-  skip_for TEXT
-);
+CREATE INDEX IF NOT EXISTS idx_summative_attempts_course
+  ON summative_attempts(course_id, attempt_number);
 
 CREATE TABLE IF NOT EXISTS drafts (
   id TEXT PRIMARY KEY,
@@ -149,6 +173,15 @@ CREATE TABLE IF NOT EXISTS pending_state (
 
 `;
 
+// Migrations for adding columns to existing tables.
+// ALTER TABLE ADD COLUMN throws if column exists; caught in init().
+const MIGRATIONS = [
+  'ALTER TABLE units ADD COLUMN journey_order INTEGER',
+  'ALTER TABLE units ADD COLUMN rubric_criteria TEXT',
+  'ALTER TABLE activities ADD COLUMN rubric_criteria TEXT',
+  'ALTER TABLE drafts ADD COLUMN rubric_criteria_scores TEXT',
+];
+
 // -- Initialization -----------------------------------------------------------
 
 export async function init() {
@@ -163,6 +196,10 @@ export async function init() {
     _db = new SQL.Database(new Uint8Array(stored[DB_STORAGE_KEY]));
     // Ensure any new tables exist (for future schema additions)
     _db.run(SCHEMA_SQL);
+    // Migrate: add new columns to existing tables (safe to re-run)
+    for (const stmt of MIGRATIONS) {
+      try { _db.run(stmt); } catch (_) { /* column already exists */ }
+    }
     // Clean up any activity rows with bare (non-scoped) IDs from before the fix
     _db.run("DELETE FROM drafts WHERE activity_id NOT LIKE '%::%'");
     _db.run("DELETE FROM messages WHERE conversation_id IN (SELECT conversation_id FROM activities WHERE id NOT LIKE '%::%')");

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -169,7 +169,7 @@ export async function generateSummative(course, allObjectives, profileSummary, p
       model: MODEL_LIGHT,
       systemPrompt,
       messages: [{ role: 'user', content: userContent }],
-      maxTokens: 1024
+      maxTokens: 2048
     });
     return parseJSON(content);
   };
@@ -294,7 +294,7 @@ export async function generateJourney(course, units, gapAnalysis, rubric, profil
       model: MODEL_LIGHT,
       systemPrompt,
       messages: [{ role: 'user', content: userContent }],
-      maxTokens: 1024
+      maxTokens: 2048
     });
     return parseJSON(content);
   };

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -49,13 +49,13 @@ async function callWithValidation(agentFn, validator, agentName) {
 
     return parsed;
   }
-  console.warn(`Validation failed (retrying): ${error}`);
+  console.error(`[1111] Validation failed (retrying): ${error}`);
 
   // Retry once
   const retry = await agentFn();
   const retryError = validator(retry);
   if (retryError) {
-    console.warn(`Validation failed after retry: ${retryError}`);
+    console.error(`[1111] Validation failed after retry: ${retryError}`);
     if (retryError.includes('unsafe')) throw new ApiError('safety', retryError);
   }
   return retry;

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -63,26 +63,37 @@ async function callWithValidation(agentFn, validator, agentName) {
 
 /**
  * Route an API call to the right backend based on auth state and configuration.
- * Priority: logged in (learn-service Bedrock) > direct Anthropic API key.
+ * Retries once on transient errors (503, 529, 500) after a short delay.
  */
 async function callApi({ model, systemPrompt, messages, maxTokens = 1024 }) {
-  // 1. Logged in → learn-service Bedrock proxy (JWT auth)
-  if (await isLoggedIn()) {
-    const resp = await authenticatedFetch('/v1/ai/messages', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ model, max_tokens: maxTokens, system: systemPrompt, messages }),
-    });
-    return parseResponse(resp);
-  }
+  const attempt = async () => {
+    if (await isLoggedIn()) {
+      const resp = await authenticatedFetch('/v1/ai/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, max_tokens: maxTokens, system: systemPrompt, messages }),
+      });
+      return parseResponse(resp);
+    }
 
-  // 2. Direct Anthropic API with user's key
-  const apiKey = await getApiKey();
-  if (apiKey) {
-    return callClaude({ apiKey, model, systemPrompt, messages, maxTokens });
-  }
+    const apiKey = await getApiKey();
+    if (apiKey) {
+      return callClaude({ apiKey, model, systemPrompt, messages, maxTokens });
+    }
 
-  throw new ApiError('invalid_key', 'No AI provider configured. Sign in or add your API key in Settings.');
+    throw new ApiError('invalid_key', 'No AI provider configured. Sign in or add your API key in Settings.');
+  };
+
+  try {
+    return await attempt();
+  } catch (e) {
+    if (e.type === 'overloaded' || (e.type === 'api' && e.status === 500)) {
+      console.error(`[1111] API ${e.status} — retrying in 3s...`);
+      await new Promise(r => setTimeout(r, 3000));
+      return attempt();
+    }
+    throw e;
+  }
 }
 
 /**

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -169,7 +169,7 @@ export async function generateSummative(course, allObjectives, profileSummary, p
       model: MODEL_LIGHT,
       systemPrompt,
       messages: [{ role: 'user', content: userContent }],
-      maxTokens: 4096
+      maxTokens: 1024
     });
     return parseJSON(content);
   };
@@ -230,7 +230,7 @@ export async function assessSummativeAttempt(course, summative, screenshots, pri
       model: MODEL_HEAVY,
       systemPrompt,
       messages: [{ role: 'user', content: contentParts }],
-      maxTokens: 2048
+      maxTokens: 1024
     });
     return parseJSON(content);
   };
@@ -261,7 +261,7 @@ export async function analyzeGaps(course, rubric, baselineResult, profileSummary
       model: MODEL_LIGHT,
       systemPrompt,
       messages: [{ role: 'user', content: userContent }],
-      maxTokens: 2048
+      maxTokens: 1024
     });
     return parseJSON(content);
   };
@@ -294,7 +294,7 @@ export async function generateJourney(course, units, gapAnalysis, rubric, profil
       model: MODEL_LIGHT,
       systemPrompt,
       messages: [{ role: 'user', content: userContent }],
-      maxTokens: 4096
+      maxTokens: 1024
     });
     return parseJSON(content);
   };

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -98,11 +98,11 @@ export async function isReady() {
  * Multi-turn conversation agent. Send a system prompt + message history,
  * get back a parsed JSON response (typically { message, done, ...extras }).
  */
-export async function converse(promptName, messages, maxTokens = 512) {
+export async function converse(promptName, messages, maxTokens = 512, { model } = {}) {
   const systemPrompt = await loadPrompt(promptName);
 
   const { content } = await callApi({
-    model: MODEL_LIGHT,
+    model: model || MODEL_LIGHT,
     systemPrompt,
     messages,
     maxTokens

--- a/js/orchestrator.js
+++ b/js/orchestrator.js
@@ -6,7 +6,10 @@
 import { callClaude, parseResponse, MODEL_LIGHT, MODEL_HEAVY, ApiError } from './api.js';
 import { isLoggedIn, authenticatedFetch } from './auth.js';
 import { getApiKey } from './storage.js';
-import { validateSafety, validateActivity, validateAssessment, validatePlan } from './validators.js';
+import {
+  validateSafety, validateActivity, validateAssessment,
+  validateSummative, validateSummativeAssessment, validateGapAnalysis, validateJourney,
+} from './validators.js';
 
 // Prompt cache (loaded once per session)
 const promptCache = {};
@@ -43,7 +46,7 @@ async function callWithValidation(agentFn, validator, agentName) {
   const parsed = await agentFn();
   const error = validator(parsed);
   if (!error) {
-  
+
     return parsed;
   }
   console.warn(`Validation failed (retrying): ${error}`);
@@ -98,7 +101,6 @@ export async function isReady() {
 export async function converse(promptName, messages, maxTokens = 512) {
   const systemPrompt = await loadPrompt(promptName);
 
-
   const { content } = await callApi({
     model: MODEL_LIGHT,
     systemPrompt,
@@ -135,24 +137,112 @@ export async function initializeLearnerProfile(name, statement) {
   return parsed;
 }
 
+// -- Summative ----------------------------------------------------------------
 
 /**
- * Create a learning plan for a unit.
+ * Generate a summative assessment (task + rubric + exemplar) for a course.
  */
-export async function createLearningPlan(unit, preferences, profileSummary, completedUnitNames, diagnosticResult, courseScope) {
-  const systemPrompt = await loadPrompt('course-creation');
+export async function generateSummative(course, allObjectives, profileSummary, personalizationNotes) {
+  const systemPrompt = await loadPrompt('summative-generation');
 
   const userContent = JSON.stringify({
-    course: {
-      courseId: unit.unitId,
-      name: unit.name,
-      description: unit.description,
-      learningObjectives: unit.learningObjectives
-    },
-    learnerProfile: profileSummary || `${preferences.name || 'Learner'}`,
-    completedCourses: completedUnitNames,
-    diagnosticResult: diagnosticResult || null,
-    courseScope: courseScope || null
+    courseName: course.name,
+    courseDescription: course.description,
+    learningObjectives: allObjectives,
+    learnerProfile: profileSummary || 'No profile yet',
+    personalizationNotes: personalizationNotes || null,
+  });
+
+  const callAgent = async () => {
+    const { content } = await callApi({
+      model: MODEL_LIGHT,
+      systemPrompt,
+      messages: [{ role: 'user', content: userContent }],
+      maxTokens: 4096
+    });
+    return parseJSON(content);
+  };
+
+  return callWithValidation(callAgent, validateSummative, 'summative-generation');
+}
+
+/**
+ * Assess a summative attempt (multi-capture, vision-based).
+ * screenshots is an array of { dataUrl, stepIndex }.
+ */
+export async function assessSummativeAttempt(course, summative, screenshots, priorAttempts, profileSummary) {
+  const systemPrompt = await loadPrompt('diagnostic-assessment');
+
+  const contentParts = [];
+
+  // Text context
+  contentParts.push({
+    type: 'text',
+    text: JSON.stringify({
+      courseName: course.name,
+      task: summative.task,
+      rubric: summative.rubric,
+      attemptNumber: (priorAttempts?.length || 0) + 1,
+      isBaseline: !priorAttempts?.length,
+      priorAttemptScores: priorAttempts?.length
+        ? priorAttempts[priorAttempts.length - 1].criteriaScores
+        : null,
+      learnerProfile: profileSummary || 'No profile yet',
+    })
+  });
+
+  // Add image blocks for each step screenshot
+  for (const ss of screenshots) {
+    if (ss.dataUrl) {
+      const match = ss.dataUrl.match(/^data:(image\/\w+);base64,(.+)$/);
+      if (match) {
+        contentParts.push({
+          type: 'text',
+          text: `Screenshot for step ${ss.stepIndex + 1}:`
+        });
+        contentParts.push({
+          type: 'image',
+          source: {
+            type: 'base64',
+            media_type: match[1],
+            data: match[2]
+          }
+        });
+      }
+    }
+  }
+
+  const bestPrior = priorAttempts?.length ? priorAttempts[priorAttempts.length - 1] : null;
+
+  const callAgent = async () => {
+    const { content } = await callApi({
+      model: MODEL_HEAVY,
+      systemPrompt,
+      messages: [{ role: 'user', content: contentParts }],
+      maxTokens: 2048
+    });
+    return parseJSON(content);
+  };
+
+  return callWithValidation(
+    callAgent,
+    (p) => validateSummativeAssessment(p, bestPrior),
+    'summative-assessment'
+  );
+}
+
+/**
+ * Analyze gaps between baseline summative attempt and mastery.
+ */
+export async function analyzeGaps(course, rubric, baselineResult, profileSummary) {
+  const systemPrompt = await loadPrompt('gap-analysis');
+
+  const userContent = JSON.stringify({
+    courseName: course.name,
+    rubric,
+    baselineScores: baselineResult.criteriaScores,
+    overallScore: baselineResult.overallScore,
+    learnerProfile: profileSummary || 'No profile yet',
   });
 
   const callAgent = async () => {
@@ -165,12 +255,46 @@ export async function createLearningPlan(unit, preferences, profileSummary, comp
     return parseJSON(content);
   };
 
-  const expectedCount = unit.learningObjectives.length;
-  return callWithValidation(callAgent, (p) => validatePlan(p, expectedCount), 'course-creation');
+  return callWithValidation(callAgent, validateGapAnalysis, 'gap-analysis');
 }
 
+// -- Journey ------------------------------------------------------------------
+
 /**
- * Generate the next activity's instruction.
+ * Generate a personalized learning journey from gap analysis.
+ */
+export async function generateJourney(course, units, gapAnalysis, rubric, profileSummary, completedFormatives) {
+  const systemPrompt = await loadPrompt('course-creation');
+
+  const userContent = JSON.stringify({
+    courseName: course.name,
+    units: units.map(u => ({
+      unitId: u.unitId, name: u.name, description: u.description,
+      learningObjectives: u.learningObjectives, dependsOn: u.dependsOn,
+    })),
+    gapAnalysis,
+    rubric,
+    learnerProfile: profileSummary || 'No profile yet',
+    completedFormatives: completedFormatives || [],
+  });
+
+  const callAgent = async () => {
+    const { content } = await callApi({
+      model: MODEL_LIGHT,
+      systemPrompt,
+      messages: [{ role: 'user', content: userContent }],
+      maxTokens: 4096
+    });
+    return parseJSON(content);
+  };
+
+  return callWithValidation(callAgent, validateJourney, 'journey-generation');
+}
+
+// -- Formative activities -----------------------------------------------------
+
+/**
+ * Generate the next formative activity's instruction.
  */
 export async function generateNextActivity(unit, planSlot, progressSummary, profileSummary, planContext, courseScope) {
   const systemPrompt = await loadPrompt('activity-creation');
@@ -178,7 +302,9 @@ export async function generateNextActivity(unit, planSlot, progressSummary, prof
   const userContent = JSON.stringify({
     course: { name: unit.name, learningObjectives: unit.learningObjectives },
     activity: { type: planSlot.type, goal: planSlot.goal },
-    workProduct: planContext?.finalWorkProductDescription || '',
+    rubricCriteria: planSlot.rubricCriteria || null,
+    gapObservation: planSlot.gapObservation || null,
+    workProduct: planContext?.workProductDescription || planContext?.finalWorkProductDescription || '',
     workProductTool: planContext?.workProductTool || '',
     priorActivities: progressSummary,
     learnerProfile: profileSummary || 'No profile yet',
@@ -199,7 +325,7 @@ export async function generateNextActivity(unit, planSlot, progressSummary, prof
 }
 
 /**
- * Assess a draft submission with vision.
+ * Assess a formative draft submission with vision.
  */
 export async function assessDraft(unit, activity, screenshotDataUrl, pageUrl, priorDrafts, profileSummary, promptName = 'activity-assessment') {
   const systemPrompt = await loadPrompt(promptName);
@@ -223,6 +349,7 @@ export async function assessDraft(unit, activity, screenshotDataUrl, pageUrl, pr
         goal: activity.goal,
         instruction: activity.instruction
       },
+      rubricCriteria: activity.rubricCriteria || null,
       pageUrl,
       priorDrafts: compressedDrafts,
       learnerProfile: profileSummary || 'No profile yet'
@@ -282,6 +409,7 @@ export async function reassessDraft(unit, activity, screenshotDataUrl, pageUrl, 
         goal: activity.goal,
         instruction: activity.instruction
       },
+      rubricCriteria: activity.rubricCriteria || null,
       pageUrl,
       priorDrafts: compressedDrafts,
       learnerProfile: profileSummary || 'No profile yet'
@@ -321,79 +449,7 @@ export async function reassessDraft(unit, activity, screenshotDataUrl, pageUrl, 
   return callWithValidation(callAgent, validateAssessment, 'assessment-reassess');
 }
 
-/**
- * Assess a diagnostic skills check from a short text response (no screenshot).
- */
-export async function assessTextResponse(unit, activity, learnerResponse, profileSummary, promptName = 'diagnostic-assessment') {
-  const systemPrompt = await loadPrompt(promptName);
-
-  const contentParts = [{
-    type: 'text',
-    text: JSON.stringify({
-      course: { name: unit.name, learningObjectives: unit.learningObjectives },
-      activity: {
-        id: activity.id,
-        type: activity.type,
-        goal: activity.goal,
-        instruction: activity.instruction
-      },
-      learnerResponse,
-      learnerProfile: profileSummary || 'No profile yet'
-    })
-  }];
-
-  const callAgent = async () => {
-    const { content } = await callApi({
-      model: MODEL_LIGHT,
-      systemPrompt,
-      messages: [{ role: 'user', content: contentParts }],
-      maxTokens: 1024
-    });
-    return parseJSON(content);
-  };
-
-  return callWithValidation(callAgent, validateAssessment, 'diagnostic-assessment');
-}
-
-/**
- * Reassess a diagnostic text response with learner feedback on the assessment.
- */
-export async function reassessTextResponse(unit, activity, learnerResponse, profileSummary, previousAssessment, learnerFeedback, promptName = 'diagnostic-assessment') {
-  const systemPrompt = await loadPrompt(promptName);
-
-  const contentParts = [{
-    type: 'text',
-    text: JSON.stringify({
-      course: { name: unit.name, learningObjectives: unit.learningObjectives },
-      activity: {
-        id: activity.id,
-        type: activity.type,
-        goal: activity.goal,
-        instruction: activity.instruction
-      },
-      learnerResponse,
-      learnerProfile: profileSummary || 'No profile yet'
-    })
-  }];
-
-  const messages = [
-    { role: 'user', content: contentParts },
-    { role: 'assistant', content: JSON.stringify(previousAssessment) },
-    { role: 'user', content: `The learner disputes this assessment: "${learnerFeedback}"\n\nRe-evaluate the same response, taking their feedback into account. You may adjust your score, recommendation, and feedback if their point is valid. Respond with the same JSON format.` }
-  ];
-
-  const callAgent = async () => {
-    const { content } = await callApi({
-      model: MODEL_LIGHT,
-      systemPrompt,
-      messages,
-      maxTokens: 1024
-    });
-    return parseJSON(content);
-  };
-
-  return callWithValidation(callAgent, validateAssessment, 'assessment-reassess');
-}
+// -- Profile updates ----------------------------------------------------------
 
 /**
  * Update the learner profile after learner feedback on an activity.
@@ -412,7 +468,6 @@ export async function updateProfileFromFeedback(fullProfile, feedbackText, activ
     }
   });
 
-
   const { content } = await callApi({
     model: MODEL_LIGHT,
     systemPrompt,
@@ -425,7 +480,7 @@ export async function updateProfileFromFeedback(fullProfile, feedbackText, activ
 }
 
 /**
- * Update the learner profile after an assessment.
+ * Update the learner profile after a formative assessment.
  */
 export async function updateLearnerProfile(fullProfile, assessmentResult, activityContext) {
   const systemPrompt = await loadPrompt('learner-profile-update');
@@ -459,35 +514,61 @@ export async function updateLearnerProfile(fullProfile, assessmentResult, activi
 }
 
 /**
- * Update the learner profile after completing an entire unit.
- * Sends the full unit context so the profile reflects all skills learned.
+ * Update the learner profile after a summative attempt.
  */
-export async function updateProfileOnUnitCompletion(fullProfile, unit, progress) {
+export async function updateProfileOnSummativeAttempt(fullProfile, course, attemptResult) {
   const systemPrompt = await loadPrompt('learner-profile-update');
-
-  // Summarize performance across all activities
-  const activitySummaries = (progress.learningPlan?.activities || []).map((slot) => {
-    const drafts = (progress.drafts || []).filter(d => d.activityId === slot.id);
-    const bestScore = drafts.length ? Math.max(...drafts.map(d => d.score ?? 0)) : null;
-    return { type: slot.type, goal: slot.goal, bestScore, draftCount: drafts.length };
-  });
 
   const userContent = JSON.stringify({
     currentProfile: fullProfile,
-    courseCompletion: {
-      unitId: unit.unitId,
-      courseName: unit.name,
-      learningObjectives: unit.learningObjectives,
-      activitySummaries,
-      workProduct: progress.learningPlan?.finalWorkProductDescription || null,
+    summativeAttempt: {
+      courseId: course.courseId,
+      courseName: course.name,
+      isBaseline: attemptResult.isBaseline,
+      mastery: attemptResult.mastery,
+      criteriaScores: attemptResult.criteriaScores,
+      overallScore: attemptResult.overallScore,
+      feedback: attemptResult.feedback,
     },
     context: {
-      event: 'unit_completed',
-      courseName: unit.name,
+      event: attemptResult.mastery ? 'summative_mastery' : (attemptResult.isBaseline ? 'summative_baseline' : 'summative_retake'),
+      courseName: course.name,
       timestamp: Date.now()
     }
   });
 
+  const { content } = await callApi({
+    model: MODEL_LIGHT,
+    systemPrompt,
+    messages: [{ role: 'user', content: userContent }],
+    maxTokens: 1024
+  });
+
+  const parsed = parseJSON(content);
+  return parsed;
+}
+
+/**
+ * Update the learner profile after achieving mastery on a course.
+ */
+export async function updateProfileOnMastery(fullProfile, course, finalResult, formativeSummaries) {
+  const systemPrompt = await loadPrompt('learner-profile-update');
+
+  const userContent = JSON.stringify({
+    currentProfile: fullProfile,
+    courseCompletion: {
+      courseId: course.courseId,
+      courseName: course.name,
+      rubricCriteriaScores: finalResult.criteriaScores,
+      overallScore: finalResult.overallScore,
+      formativeSummaries,
+    },
+    context: {
+      event: 'course_mastery',
+      courseName: course.name,
+      timestamp: Date.now()
+    }
+  });
 
   const { content } = await callApi({
     model: MODEL_LIGHT,

--- a/js/storage.js
+++ b/js/storage.js
@@ -27,43 +27,6 @@ export async function getUnitProgress(unitId) {
   const unitRow = query('SELECT * FROM units WHERE unit_id = ?', [unitId]);
   if (!unitRow) return null;
 
-  // Learning plan
-  const planRow = query('SELECT * FROM learning_plans WHERE unit_id = ?', [unitId]);
-  let learningPlan = null;
-  if (planRow) {
-    // Reconstruct plan activities from the plan's stored data
-    const planData = planRow.data ? JSON.parse(planRow.data) : null;
-    learningPlan = {
-      activities: planData?.activities || [],
-      finalWorkProductDescription: planRow.final_work_product_description,
-      workProductTool: planRow.work_product_tool,
-    };
-  }
-
-  // Diagnostic
-  const diagRow = query('SELECT * FROM diagnostics WHERE unit_id = ?', [unitId]);
-  let diagnostic = null;
-  if (diagRow) {
-    const diagMessages = diagRow.conversation_id
-      ? queryAll(
-          'SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY timestamp',
-          [diagRow.conversation_id]
-        )
-      : [];
-    diagnostic = {
-      instruction: diagRow.instruction,
-      messages: diagMessages.map(m => ({ role: m.role, content: m.content })),
-      result: diagRow.score != null ? {
-        score: diagRow.score,
-        feedback: diagRow.feedback,
-        strengths: diagRow.strengths ? JSON.parse(diagRow.strengths) : [],
-        improvements: diagRow.improvements ? JSON.parse(diagRow.improvements) : [],
-        recommendation: diagRow.recommendation,
-        passed: !!diagRow.passed,
-      } : null,
-    };
-  }
-
   // Activities
   const activityRows = queryAll(
     'SELECT * FROM activities WHERE unit_id = ? ORDER BY sequence',
@@ -76,7 +39,6 @@ export async function getUnitProgress(unitId) {
           [a.conversation_id]
         )
       : [];
-    // Strip unit prefix from DB id to return the original activity id
     const originalId = a.id.includes('::') ? a.id.split('::')[1] : a.id;
     return {
       id: originalId,
@@ -84,6 +46,7 @@ export async function getUnitProgress(unitId) {
       goal: a.goal,
       instruction: a.instruction,
       tips: a.tips,
+      rubricCriteria: a.rubric_criteria ? JSON.parse(a.rubric_criteria) : null,
       messages: msgs.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })),
     };
   });
@@ -103,15 +66,17 @@ export async function getUnitProgress(unitId) {
     improvements: d.improvements ? JSON.parse(d.improvements) : [],
     score: d.score,
     recommendation: d.recommendation,
+    rubricCriteriaScores: d.rubric_criteria_scores ? JSON.parse(d.rubric_criteria_scores) : null,
     timestamp: d.timestamp,
   }));
 
   return {
     unitId: unitRow.unit_id,
+    courseId: unitRow.course_id,
     status: unitRow.status,
     currentActivityIndex: unitRow.current_activity_index,
-    diagnostic,
-    learningPlan,
+    journeyOrder: unitRow.journey_order,
+    rubricCriteria: unitRow.rubric_criteria ? JSON.parse(unitRow.rubric_criteria) : null,
     activities,
     drafts,
     startedAt: unitRow.started_at,
@@ -131,77 +96,19 @@ export async function saveUnitProgress(unitId, progress) {
     run(
       `INSERT OR REPLACE INTO units
        (unit_id, course_id, name, description, depends_on, sequence, status,
-        current_activity_index, started_at, completed_at, final_work_product_url)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        current_activity_index, started_at, completed_at, final_work_product_url,
+        journey_order, rubric_criteria)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         unitId, courseId, '', '', null, 0, progress.status || 'not_started',
         progress.currentActivityIndex || 0,
         progress.startedAt || null,
         progress.completedAt || null,
         progress.finalWorkProductUrl || null,
+        progress.journeyOrder ?? null,
+        progress.rubricCriteria ? JSON.stringify(progress.rubricCriteria) : null,
       ]
     );
-
-    // Upsert learning plan
-    if (progress.learningPlan) {
-      run(
-        `INSERT OR REPLACE INTO learning_plans
-         (unit_id, final_work_product_description, work_product_tool, data, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
-        [
-          unitId,
-          progress.learningPlan.finalWorkProductDescription || null,
-          progress.learningPlan.workProductTool || null,
-          JSON.stringify(progress.learningPlan),
-          Date.now(),
-        ]
-      );
-    }
-
-    // Upsert diagnostic
-    if (progress.diagnostic) {
-      const diagConvId = `diag-${unitId}`;
-      // Ensure conversation exists
-      run(
-        'INSERT OR IGNORE INTO conversations (id, unit_id, type, created_at) VALUES (?, ?, ?, ?)',
-        [diagConvId, unitId, 'diagnostic', Date.now()]
-      );
-      // Replace messages
-      run('DELETE FROM messages WHERE conversation_id = ?', [diagConvId]);
-      const diagMsgs = progress.diagnostic.messages || [];
-      for (let i = 0; i < diagMsgs.length; i++) {
-        const m = diagMsgs[i];
-        run(
-          'INSERT INTO messages (conversation_id, role, content, timestamp) VALUES (?, ?, ?, ?)',
-          [diagConvId, m.role, m.content, m.timestamp || Date.now()]
-        );
-      }
-      const result = progress.diagnostic.result;
-      run(
-        `INSERT OR REPLACE INTO diagnostics
-         (unit_id, conversation_id, instruction, score, feedback, strengths, improvements, recommendation, passed)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [
-          unitId, diagConvId,
-          progress.diagnostic.instruction || null,
-          result?.score ?? null,
-          result?.feedback || null,
-          result?.strengths ? JSON.stringify(result.strengths) : null,
-          result?.improvements ? JSON.stringify(result.improvements) : null,
-          result?.recommendation || null,
-          result?.passed ? 1 : 0,
-        ]
-      );
-    } else {
-      // Remove diagnostic if cleared
-      const existingDiag = query('SELECT conversation_id FROM diagnostics WHERE unit_id = ?', [unitId]);
-      if (existingDiag) {
-        if (existingDiag.conversation_id) {
-          run('DELETE FROM messages WHERE conversation_id = ?', [existingDiag.conversation_id]);
-        }
-        run('DELETE FROM diagnostics WHERE unit_id = ?', [unitId]);
-      }
-    }
 
     // Upsert activities
     // First, collect existing activity conversation IDs to clean up orphans
@@ -236,9 +143,10 @@ export async function saveUnitProgress(unitId, progress) {
 
       run(
         `INSERT OR REPLACE INTO activities
-         (id, unit_id, type, goal, instruction, tips, sequence, conversation_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [dbActId, unitId, a.type, a.goal, a.instruction || null, a.tips || null, i, convId]
+         (id, unit_id, type, goal, instruction, tips, sequence, conversation_id, rubric_criteria)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [dbActId, unitId, a.type, a.goal, a.instruction || null, a.tips || null, i, convId,
+         a.rubricCriteria ? JSON.stringify(a.rubricCriteria) : null]
       );
     }
 
@@ -265,8 +173,8 @@ export async function saveUnitProgress(unitId, progress) {
       run(
         `INSERT OR REPLACE INTO drafts
          (id, activity_id, unit_id, screenshot_key, url, score, feedback,
-          strengths, improvements, recommendation, timestamp)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          strengths, improvements, recommendation, timestamp, rubric_criteria_scores)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           draftId, `${unitId}::${d.activityId}`, unitId,
           d.screenshotKey || null,
@@ -277,6 +185,7 @@ export async function saveUnitProgress(unitId, progress) {
           d.improvements ? JSON.stringify(d.improvements) : null,
           d.recommendation || null,
           d.timestamp || Date.now(),
+          d.rubricCriteriaScores ? JSON.stringify(d.rubricCriteriaScores) : null,
         ]
       );
     }
@@ -431,22 +340,181 @@ export async function saveOnboardingComplete() {
 }
 
 
-// -- Conversation state (diagnostic + onboarding) -----------------------------
+// -- Summative ----------------------------------------------------------------
 
-export async function getDiagnosticState() {
-  const row = query("SELECT state_json FROM pending_state WHERE key = 'diagnostic'");
-  return row ? JSON.parse(row.state_json) : null;
+export async function getSummative(courseId) {
+  const row = query('SELECT * FROM summatives WHERE course_id = ?', [courseId]);
+  if (!row) return null;
+  return {
+    courseId: row.course_id,
+    task: JSON.parse(row.task),
+    rubric: JSON.parse(row.rubric),
+    exemplar: row.exemplar,
+    tool: row.tool,
+    estimatedTime: row.estimated_time,
+    personalized: !!row.personalized,
+    conversationId: row.conversation_id,
+    createdAt: row.created_at,
+  };
 }
 
-export async function saveDiagnosticState(diagState) {
+export async function saveSummative(courseId, data) {
   run(
-    "INSERT OR REPLACE INTO pending_state (key, state_json, updated_at) VALUES ('diagnostic', ?, ?)",
-    [JSON.stringify(diagState), Date.now()]
+    `INSERT OR REPLACE INTO summatives
+     (course_id, task, rubric, exemplar, tool, estimated_time, personalized, conversation_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      courseId,
+      JSON.stringify(data.task),
+      JSON.stringify(data.rubric),
+      data.exemplar,
+      data.tool || null,
+      data.estimatedTime || null,
+      data.personalized ? 1 : 0,
+      data.conversationId || null,
+      data.createdAt || Date.now(),
+    ]
   );
 }
 
-export async function clearDiagnosticState() {
-  run("DELETE FROM pending_state WHERE key = 'diagnostic'");
+// -- Summative Attempts -------------------------------------------------------
+
+export async function getSummativeAttempts(courseId) {
+  const rows = queryAll(
+    'SELECT * FROM summative_attempts WHERE course_id = ? ORDER BY attempt_number',
+    [courseId]
+  );
+  return rows.map(r => ({
+    id: r.id,
+    courseId: r.course_id,
+    attemptNumber: r.attempt_number,
+    screenshots: r.screenshots ? JSON.parse(r.screenshots) : [],
+    criteriaScores: r.criteria_scores ? JSON.parse(r.criteria_scores) : [],
+    overallScore: r.overall_score,
+    mastery: !!r.mastery,
+    feedback: r.feedback,
+    nextSteps: r.next_steps ? JSON.parse(r.next_steps) : [],
+    isBaseline: !!r.is_baseline,
+    timestamp: r.timestamp,
+  }));
+}
+
+export async function saveSummativeAttempt(courseId, attempt) {
+  run(
+    `INSERT OR REPLACE INTO summative_attempts
+     (id, course_id, attempt_number, screenshots, criteria_scores, overall_score,
+      mastery, feedback, next_steps, is_baseline, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      attempt.id,
+      courseId,
+      attempt.attemptNumber,
+      JSON.stringify(attempt.screenshots || []),
+      JSON.stringify(attempt.criteriaScores || []),
+      attempt.overallScore ?? null,
+      attempt.mastery ? 1 : 0,
+      attempt.feedback || null,
+      attempt.nextSteps ? JSON.stringify(attempt.nextSteps) : null,
+      attempt.isBaseline ? 1 : 0,
+      attempt.timestamp || Date.now(),
+    ]
+  );
+}
+
+// -- Gap Analysis -------------------------------------------------------------
+
+export async function getGapAnalysis(courseId) {
+  const row = query('SELECT * FROM gap_analysis WHERE course_id = ?', [courseId]);
+  if (!row) return null;
+  return {
+    courseId: row.course_id,
+    gaps: JSON.parse(row.gaps),
+    suggestedFocus: row.suggested_focus ? JSON.parse(row.suggested_focus) : [],
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function saveGapAnalysis(courseId, data) {
+  run(
+    `INSERT OR REPLACE INTO gap_analysis
+     (course_id, gaps, suggested_focus, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [
+      courseId,
+      JSON.stringify(data.gaps),
+      data.suggestedFocus ? JSON.stringify(data.suggestedFocus) : null,
+      data.createdAt || Date.now(),
+      Date.now(),
+    ]
+  );
+}
+
+// -- Journey ------------------------------------------------------------------
+
+export async function getJourney(courseId) {
+  const row = query('SELECT * FROM journeys WHERE course_id = ?', [courseId]);
+  if (!row) return null;
+  return {
+    courseId: row.course_id,
+    plan: JSON.parse(row.plan),
+    phase: row.phase,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function saveJourney(courseId, data) {
+  run(
+    `INSERT OR REPLACE INTO journeys
+     (course_id, plan, phase, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [
+      courseId,
+      JSON.stringify(data.plan),
+      data.phase || 'summative_setup',
+      data.createdAt || Date.now(),
+      Date.now(),
+    ]
+  );
+}
+
+export async function updateJourneyPhase(courseId, phase) {
+  run(
+    'UPDATE journeys SET phase = ?, updated_at = ? WHERE course_id = ?',
+    [phase, Date.now(), courseId]
+  );
+}
+
+// -- Course Phase (derived) ---------------------------------------------------
+
+export async function getCoursePhase(courseId) {
+  const journey = query('SELECT phase FROM journeys WHERE course_id = ?', [courseId]);
+  if (journey) return journey.phase;
+  // No journey record yet — check if summative exists
+  const summative = query('SELECT course_id FROM summatives WHERE course_id = ?', [courseId]);
+  if (summative) return 'summative_setup';
+  return null;
+}
+
+// -- Conversation state (rubric review + onboarding) --------------------------
+
+export async function getRubricReviewState(courseId) {
+  const key = `rubric-review:${courseId}`;
+  const row = query('SELECT state_json FROM pending_state WHERE key = ?', [key]);
+  return row ? JSON.parse(row.state_json) : null;
+}
+
+export async function saveRubricReviewState(courseId, state) {
+  const key = `rubric-review:${courseId}`;
+  run(
+    'INSERT OR REPLACE INTO pending_state (key, state_json, updated_at) VALUES (?, ?, ?)',
+    [key, JSON.stringify(state), Date.now()]
+  );
+}
+
+export async function clearRubricReviewState(courseId) {
+  run('DELETE FROM pending_state WHERE key = ?', [`rubric-review:${courseId}`]);
 }
 
 export async function getOnboardingState() {
@@ -495,15 +563,20 @@ export async function deleteUnitProgress(unitId) {
     }
   }
   run('DELETE FROM activities WHERE unit_id = ?', [unitId]);
-
-  const diag = query('SELECT conversation_id FROM diagnostics WHERE unit_id = ?', [unitId]);
-  if (diag?.conversation_id) {
-    run('DELETE FROM messages WHERE conversation_id = ?', [diag.conversation_id]);
-    run('DELETE FROM conversations WHERE id = ?', [diag.conversation_id]);
-  }
-  run('DELETE FROM diagnostics WHERE unit_id = ?', [unitId]);
-  run('DELETE FROM learning_plans WHERE unit_id = ?', [unitId]);
   run('DELETE FROM units WHERE unit_id = ?', [unitId]);
+}
+
+export async function deleteCourseProgress(courseId) {
+  // Delete summative data
+  run('DELETE FROM summative_attempts WHERE course_id = ?', [courseId]);
+  run('DELETE FROM summatives WHERE course_id = ?', [courseId]);
+  run('DELETE FROM gap_analysis WHERE course_id = ?', [courseId]);
+  run('DELETE FROM journeys WHERE course_id = ?', [courseId]);
+  // Delete all units for this course
+  const units = queryAll('SELECT unit_id FROM units WHERE course_id = ?', [courseId]);
+  for (const u of units) {
+    await deleteUnitProgress(u.unit_id);
+  }
 }
 
 // -- IndexedDB for binary assets (screenshots) --------------------------------

--- a/js/sync.js
+++ b/js/sync.js
@@ -13,6 +13,10 @@ import {
   getUnitProgress, saveUnitProgress, getAllProgress,
   deleteProfile, deleteProfileSummary, deletePreferences,
   deleteWorkProducts, deleteUnitProgress,
+  getSummative, saveSummative,
+  getSummativeAttempts, saveSummativeAttempt,
+  getGapAnalysis, saveGapAnalysis,
+  getJourney, saveJourney,
 } from './storage.js';
 
 // In-memory version map — tracks the server's version per key for optimistic locking.
@@ -102,6 +106,10 @@ async function getLocalData(syncKey) {
   if (syncKey === 'profileSummary') return getLearnerProfileSummary().then(s => s || null);
   if (syncKey === 'preferences') return getPreferences();
   if (syncKey === 'work') return getWorkProducts();
+  if (syncKey.startsWith('summative:')) return getSummative(syncKey.slice('summative:'.length));
+  if (syncKey.startsWith('summative-attempts:')) return getSummativeAttempts(syncKey.slice('summative-attempts:'.length));
+  if (syncKey.startsWith('gap:')) return getGapAnalysis(syncKey.slice('gap:'.length));
+  if (syncKey.startsWith('journey:')) return getJourney(syncKey.slice('journey:'.length));
   if (syncKey.startsWith('progress:')) {
     const progress = await getUnitProgress(syncKey.slice('progress:'.length));
     if (!progress) return null;
@@ -131,6 +139,16 @@ async function saveLocalData(syncKey, data) {
       for (const product of data) await saveWorkProduct(product);
     })();
   }
+  if (syncKey.startsWith('summative:')) return saveSummative(syncKey.slice('summative:'.length), data);
+  if (syncKey.startsWith('summative-attempts:')) {
+    // Attempts come as an array — save each one
+    for (const attempt of (Array.isArray(data) ? data : [data])) {
+      await saveSummativeAttempt(syncKey.slice('summative-attempts:'.length), attempt);
+    }
+    return;
+  }
+  if (syncKey.startsWith('gap:')) return saveGapAnalysis(syncKey.slice('gap:'.length), data);
+  if (syncKey.startsWith('journey:')) return saveJourney(syncKey.slice('journey:'.length), data);
   if (syncKey.startsWith('progress:')) {
     // Extract and store embedded screenshots, then save progress without them
     const { saveScreenshot } = await import('./storage.js');

--- a/js/validators.js
+++ b/js/validators.js
@@ -10,16 +10,10 @@ export const NON_BROWSER_APP = /\b(open\s+(your\s+)?(text\s+editor|terminal|comm
 export const DEVTOOLS_PATTERN = /\b(DevTools|dev\s+tools|Inspect\s+Element|Lighthouse|open\s+(the\s+)?console|right[- ]click.{0,20}inspect|Elements?\s+(panel|tab)|Network\s+(panel|tab)|Sources?\s+(panel|tab)|F12)\b/i;
 export const PRODUCES_WORK = /\b(write|type|create|build|draft|compose|summarize|list|outline|note|annotate|describe|explain|fill\s+(in|out)|enter|paste|edit|modify|change|add|code|implement|design)\b/i;
 
+const VALID_MASTERY_LEVELS = ['beginning', 'developing', 'proficient', 'mastery'];
+
 export function validateSafety(text) {
   if (UNSAFE_PATTERNS.test(text)) return 'Response contains unsafe content.';
-  return null;
-}
-
-export function validateDiagnosticActivity(parsed) {
-  if (!parsed.instruction || typeof parsed.instruction !== 'string') return 'Missing instruction.';
-  if (!Array.isArray(parsed.tips)) return 'Missing tips array.';
-  const safety = validateSafety(parsed.instruction + ' ' + parsed.tips.join(' '));
-  if (safety) return safety;
   return null;
 }
 
@@ -76,17 +70,98 @@ export function validateAssessment(parsed) {
   return null;
 }
 
-export function validatePlan(parsed, expectedCount) {
-  if (!Array.isArray(parsed.activities)) return 'Missing activities array.';
-  if (parsed.activities.length !== expectedCount) return `Expected ${expectedCount} activities (one per objective), got ${parsed.activities.length}.`;
-  if (!parsed.finalWorkProductDescription || typeof parsed.finalWorkProductDescription !== 'string') return 'Missing finalWorkProductDescription.';
-  if (!parsed.workProductTool || typeof parsed.workProductTool !== 'string') return 'Missing workProductTool.';
-  const last = parsed.activities[parsed.activities.length - 1];
-  if (last.type !== 'final') return 'Last activity must be type "final".';
-  // No two consecutive activities should have the same type
-  for (let i = 1; i < parsed.activities.length; i++) {
-    if (parsed.activities[i].type === parsed.activities[i - 1].type) {
-      return `Activities ${i} and ${i + 1} have the same type "${parsed.activities[i].type}" — each must be different from the previous.`;
+// -- Summative validators -----------------------------------------------------
+
+export function validateSummative(parsed) {
+  if (!parsed.task) return 'Missing task.';
+  if (!Array.isArray(parsed.task.steps) || parsed.task.steps.length === 0) return 'Task must have a steps array with at least one step.';
+  for (let i = 0; i < parsed.task.steps.length; i++) {
+    const step = parsed.task.steps[i];
+    if (!step.instruction || typeof step.instruction !== 'string') return `Step ${i + 1} missing instruction.`;
+  }
+  if (!Array.isArray(parsed.rubric) || parsed.rubric.length === 0) return 'Rubric must be a non-empty array of criteria.';
+  for (let i = 0; i < parsed.rubric.length; i++) {
+    const c = parsed.rubric[i];
+    if (!c.name || typeof c.name !== 'string') return `Rubric criterion ${i + 1} missing name.`;
+    if (!c.levels || typeof c.levels !== 'object') return `Rubric criterion "${c.name}" missing levels.`;
+    for (const level of VALID_MASTERY_LEVELS) {
+      if (!c.levels[level] || typeof c.levels[level] !== 'string') {
+        return `Rubric criterion "${c.name}" missing "${level}" level description.`;
+      }
+    }
+  }
+  if (!parsed.exemplar || typeof parsed.exemplar !== 'string') return 'Missing exemplar.';
+
+  const allText = parsed.exemplar + ' ' + parsed.task.steps.map(s => s.instruction).join(' ');
+  const safety = validateSafety(allText);
+  if (safety) return safety;
+
+  return null;
+}
+
+export function validateSummativeAssessment(parsed, priorAttempt) {
+  if (!Array.isArray(parsed.criteriaScores) || parsed.criteriaScores.length === 0) {
+    return 'Missing criteriaScores array.';
+  }
+  for (let i = 0; i < parsed.criteriaScores.length; i++) {
+    const cs = parsed.criteriaScores[i];
+    if (!cs.criterion || typeof cs.criterion !== 'string') return `Criterion score ${i + 1} missing criterion name.`;
+    if (!VALID_MASTERY_LEVELS.includes(cs.level)) return `Criterion "${cs.criterion}" has invalid level "${cs.level}".`;
+    if (typeof cs.score !== 'number' || cs.score < 0 || cs.score > 1) return `Criterion "${cs.criterion}" score must be 0.0-1.0.`;
+  }
+  if (typeof parsed.overallScore !== 'number' || parsed.overallScore < 0 || parsed.overallScore > 1) {
+    return 'overallScore must be 0.0-1.0.';
+  }
+  if (typeof parsed.mastery !== 'boolean') return 'mastery must be a boolean.';
+  if (!parsed.feedback || typeof parsed.feedback !== 'string') return 'Missing feedback.';
+
+  // Ratchet rule: no criterion score can be lower than the prior attempt
+  if (priorAttempt?.criteriaScores) {
+    const priorMap = {};
+    for (const ps of priorAttempt.criteriaScores) {
+      priorMap[ps.criterion] = ps.score;
+    }
+    for (const cs of parsed.criteriaScores) {
+      const priorScore = priorMap[cs.criterion];
+      if (priorScore != null && cs.score < priorScore) {
+        return `Criterion "${cs.criterion}" score ${cs.score} is lower than prior ${priorScore} — scores can only go up.`;
+      }
+    }
+  }
+
+  const safety = validateSafety(parsed.feedback);
+  if (safety) return safety;
+
+  return null;
+}
+
+export function validateGapAnalysis(parsed) {
+  if (!Array.isArray(parsed.gaps) || parsed.gaps.length === 0) return 'Missing gaps array.';
+  for (let i = 0; i < parsed.gaps.length; i++) {
+    const g = parsed.gaps[i];
+    if (!g.criterion || typeof g.criterion !== 'string') return `Gap ${i + 1} missing criterion.`;
+    if (!VALID_MASTERY_LEVELS.includes(g.currentLevel)) return `Gap "${g.criterion}" has invalid currentLevel.`;
+    if (!VALID_MASTERY_LEVELS.includes(g.targetLevel)) return `Gap "${g.criterion}" has invalid targetLevel.`;
+    if (!['high', 'medium', 'low'].includes(g.priority)) return `Gap "${g.criterion}" has invalid priority.`;
+  }
+  return null;
+}
+
+export function validateJourney(parsed) {
+  if (!Array.isArray(parsed.units) || parsed.units.length === 0) return 'Missing units array.';
+  for (let i = 0; i < parsed.units.length; i++) {
+    const u = parsed.units[i];
+    if (!u.unitId || typeof u.unitId !== 'string') return `Journey unit ${i + 1} missing unitId.`;
+    if (!Array.isArray(u.activities) || u.activities.length === 0) {
+      return `Journey unit "${u.unitId}" must have at least one activity.`;
+    }
+    for (let j = 0; j < u.activities.length; j++) {
+      const a = u.activities[j];
+      if (!a.type || typeof a.type !== 'string') return `Activity ${j + 1} in unit "${u.unitId}" missing type.`;
+      if (!a.goal || typeof a.goal !== 'string') return `Activity ${j + 1} in unit "${u.unitId}" missing goal.`;
+      if (!Array.isArray(a.rubricCriteria) || a.rubricCriteria.length === 0) {
+        return `Activity ${j + 1} in unit "${u.unitId}" must target at least one rubric criterion.`;
+      }
     }
   }
   return null;

--- a/js/validators.js
+++ b/js/validators.js
@@ -10,7 +10,7 @@ export const NON_BROWSER_APP = /\b(open\s+(your\s+)?(text\s+editor|terminal|comm
 export const DEVTOOLS_PATTERN = /\b(DevTools|dev\s+tools|Inspect\s+Element|Lighthouse|open\s+(the\s+)?console|right[- ]click.{0,20}inspect|Elements?\s+(panel|tab)|Network\s+(panel|tab)|Sources?\s+(panel|tab)|F12)\b/i;
 export const PRODUCES_WORK = /\b(write|type|create|build|draft|compose|summarize|list|outline|note|annotate|describe|explain|fill\s+(in|out)|enter|paste|edit|modify|change|add|code|implement|design)\b/i;
 
-const VALID_MASTERY_LEVELS = ['beginning', 'developing', 'proficient', 'mastery'];
+const VALID_MASTERY_LEVELS = ['incomplete', 'approaching', 'meets', 'exceeds'];
 
 export function validateSafety(text) {
   if (UNSAFE_PATTERNS.test(text)) return 'Response contains unsafe content.';

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -14,6 +14,10 @@ If a learner profile is provided, use it to personalize your assessment:
 - Frame improvements in terms of their goals and interests, not generic advice.
 - Note new evidence of strengths or gaps that the profile should capture — the profile agent will read your assessment to update the learner's record.
 
+## Rubric criteria (assessment-backward design)
+
+If `rubricCriteria` is provided, this activity targets specific criteria from the course's summative rubric. In addition to the standard assessment, evaluate how well the work demonstrates progress on these specific criteria. Include a `rubricCriteriaScores` array with a level and score for each targeted criterion.
+
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person.
@@ -37,5 +41,14 @@ Respond with ONLY valid JSON, no markdown fencing:
   "improvements": ["...", "..."],
   "score": 0.85,
   "recommendation": "advance",
-  "passed": true
+  "passed": true,
+  "rubricCriteriaScores": [
+    {
+      "criterion": "Criterion name from rubric",
+      "level": "developing",
+      "score": 0.45
+    }
+  ]
 }
+
+If no rubricCriteria were provided, omit the rubricCriteriaScores field entirely.

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -20,7 +20,7 @@ If `rubricCriteria` is provided, this activity targets specific criteria from th
 
 ## Rules
 
-- Address the learner directly as "you" — never refer to them as "the learner" or in third person.
+- Address the learner directly as "you" — never refer to them as "the learner" or in third person. Use their first name when available — never their full name.
 - Write in plain, simple language. Short sentences. No jargon.
 - Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.

--- a/prompts/activity-assessment.md
+++ b/prompts/activity-assessment.md
@@ -21,6 +21,7 @@ If `rubricCriteria` is provided, this activity targets specific criteria from th
 ## Rules
 
 - Address the learner directly as "you" — never refer to them as "the learner" or in third person. Use their first name when available — never their full name.
+- Default tone is direct and professional — no filler pleasantries ("Great job!", "How exciting"). Only shift warmer if the learner profile's communication style calls for it.
 - Write in plain, simple language. Short sentences. No jargon.
 - Feedback: 1-2 sentences about what you see and whether it demonstrates understanding of the goal.
 - Strengths: 1-3 bullet points, one sentence each. Focus on evidence of understanding.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -57,6 +57,13 @@ Good: "The four WordPress freedoms are: (1) use the software for any purpose, (2
 Good: "Search the web for 'WordPress major milestones timeline'. In your post, write about three milestones that surprised you or stood out."
 Bad: "Research the WordPress freedoms and write about them in your post." (no starting point — the learner doesn't know where to look or what the freedoms are)
 
+## Rubric criteria (assessment-backward design)
+
+If `rubricCriteria` is provided, this activity targets specific criteria from the course's summative rubric. The activity must build the learner's ability on these criteria:
+- Frame the activity so the learner practices skills that directly address the rubric criteria.
+- If `gapObservation` is provided, address what the learner was missing — don't re-teach what they already demonstrated.
+- The activity should move the learner from their current level toward proficiency on these criteria.
+
 ## Use the learner profile and course scope
 
 If a learner profile is provided, personalize the activity:

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -68,6 +68,7 @@ If `rubricCriteria` is provided, this activity targets specific criteria from th
 
 If a learner profile is provided, personalize the activity:
 - Use the learner's first name when addressing them — never their full name.
+- Default tone is direct and professional — no filler pleasantries. Only shift warmer if the learner profile's communication style calls for it.
 - Match the learner's communication style (noted in the profile). Use vocabulary and tone that feel natural to them — never talk down or over-explain to experienced learners, and never use jargon with beginners.
 - Reference their interests, goals, or field when framing the activity.
 - Build on demonstrated strengths rather than re-teaching basics.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -67,6 +67,7 @@ If `rubricCriteria` is provided, this activity targets specific criteria from th
 ## Use the learner profile and course scope
 
 If a learner profile is provided, personalize the activity:
+- Use the learner's first name when addressing them — never their full name.
 - Match the learner's communication style (noted in the profile). Use vocabulary and tone that feel natural to them — never talk down or over-explain to experienced learners, and never use jargon with beginners.
 - Reference their interests, goals, or field when framing the activity.
 - Build on demonstrated strengths rather than re-teaching basics.

--- a/prompts/activity-creation.md
+++ b/prompts/activity-creation.md
@@ -98,9 +98,8 @@ Learners may be on any device (Mac, Windows, Chromebook, Android, iOS). Never us
 
 ## Format
 
-- One short sentence explaining the goal.
-- Numbered steps (1, 2, 3). Each step is one short sentence. Aim for 3 steps plus the Capture step (4 total). Never exceed 4 steps and never use fewer than 3 steps before the Capture step.
-- Each step should be one action only — do not pack multiple actions or sub-tasks into a single step.
+- One short sentence explaining the goal. No preamble.
+- Numbered steps (1, 2, 3). Each step is one concise sentence — one action, no sub-tasks. Aim for 3 steps plus the Capture step (4 total). Never exceed 4 steps and never use fewer than 3 steps before the Capture step.
 - The final step is ALWAYS: "Hit Capture to capture your screen."
 - Plain, simple language. No jargon. 5 minutes or less.
 - Include 2-3 tips (one short sentence each).

--- a/prompts/course-creation.md
+++ b/prompts/course-creation.md
@@ -1,74 +1,58 @@
-You are the Course Creation Agent for 1111, an agentic learning app.
+You are the Journey Generation Agent for 1111, an agentic learning app.
 
-Your job is to create a personalized learning plan for a unit. You receive the unit definition, a learner profile summary, a list of units the learner has completed, and optionally the course scope (which course this unit belongs to, whether it's required or optional, and sibling units).
+Your job is to create a personalized learning journey for a course. You receive the gap analysis (per-criterion gaps from the baseline summative attempt), the summative rubric, the predefined units with their learning objectives, the learner's profile summary, and optionally completed formative activities.
 
-Design a sequence of small, focused activities that guide the learner through the unit's objectives. All activities build toward ONE work product in ONE place. If a courseScope is provided, use it to connect activities to the broader course narrative — reference what the learner has done in prior units or what's coming next.
+## Assessment-backward design
 
-## Learn by doing
+Everything is designed backward from the summative assessment. Each formative activity you plan must target specific rubric criteria where the learner has gaps. The goal is to close every gap so the learner can demonstrate mastery on the summative retake.
 
-Every activity must TEACH something. The learner builds the work product by learning as they go — never by following a template or setting up empty structure. There are no "setup" or "scaffolding" activities. The very first activity should have the learner learning something real and starting their work product.
+## What you decide
 
-Bad plan: "1. Research topic A → 2. Research topic B → 3. Finalize" (activities 1 and 2 are the same kind of task)
-Good plan: "1. Research topics A and B and capture findings in your work product → 2. Apply what you learned by building something → 3. Revise, connect, and finalize"
-
-The work product's structure should emerge organically from the learner's work, not be prescribed up front.
-
-## Single work product rule
-
-Every course revolves around a single browser-based work product. The first activity creates it and starts real work. Every subsequent activity returns to it to add, revise, or refine.
-
-**Choose the tool that fits the course subject.** If the course is about a specific browser-accessible platform (WordPress Playground, CodePen, Notion, Replit, Figma, etc.), the work product must be created and built inside that platform — not in a generic writing tool. Only default to Google Doc when the course is about general writing, research, or a topic with no dedicated browser tool.
-
-The work product might be a Google Doc, a WordPress post, a CodePen pen, a Figma file, etc. Use language appropriate to the tool — e.g. "post" for WordPress, "pen" for CodePen, "page" for Notion — not "document" for everything.
-
-You MUST specify the tool in `workProductTool` (e.g. "Google Doc", "CodePen", "Notion page", "WordPress Playground post").
+1. **Which units to include** — skip units whose objectives are already covered (the learner showed proficiency on those criteria in the baseline).
+2. **Unit order** — sequence units so prerequisite skills are built before advanced ones. Respect `dependsOn` fields.
+3. **Activity count per unit** — more activities for larger gaps, fewer for smaller ones. Minimum 1, maximum 5 per unit.
+4. **Activity specs** — for each activity, define the type, goal, and which rubric criteria it targets.
 
 ## Activity types
 
-- **explore**: Research a topic and add findings to the work product in the learner's own words
-- **apply**: Practice a skill by working on the work product
-- **create**: Revise, restructure, or expand the work product
-- **final**: Polish and finalize the completed work product
-
-## Activity count (STRICT)
-
-Generate EXACTLY one activity per learning objective — no more, no fewer. If there are 5 learning objectives, output exactly 5 activities. The `objectiveIndex` field maps each activity to its objective (0-indexed). This is validated programmatically and will be rejected if the count doesn't match.
-
-## Activity variety (STRICT)
-
-Each activity MUST use a different activity type from the one before it. Never use the same type twice in a row. Each activity should build on the previous one — deepen, apply, or transform what came before. The last activity must always be type "final".
+- **explore**: Research a topic and capture findings
+- **apply**: Practice a skill by building something
+- **create**: Revise, restructure, or expand work
+- **final**: Polish and demonstrate mastery of the unit's contribution to the summative
 
 ## Rules
 
-- Every activity must be completable in 5 minutes or less.
-- Activity goals describe WHAT to learn and WHERE to put it — never WHAT to write. The learner decides the content.
-- Never assume the learner already knows the subject matter. Each activity should be a learning opportunity, not a test of existing knowledge.
-- Each activity goal must describe ONE simple task with ONE visible outcome on ONE webpage (the work product). The learner will be assessed by a screenshot of a single browser tab. The screenshot only captures what fits in one viewport (no scrolling), so each activity must produce SMALL output — a few sentences, a short list, or a visible change. Never design activities that result in long-form writing like essays, reports, or multiple paragraphs.
-- NEVER write goals that involve multiple websites, multiple tools, or multiple outcomes.
-- All activities must be doable entirely in the browser. Never reference desktop apps, terminals, or file system operations.
-- Adapt difficulty and pacing to the learner's profile.
-- If the learner has completed related courses, reference that experience.
-- Keep activity goals to one short sentence.
-- Include a brief rationale explaining your plan design.
-- finalWorkProductDescription must be a short name (2-4 words) for the deliverable, like "Accessibility Audit Report", "WordPress Portfolio", or "AI Ethics Doc". NOT a full description.
+- Every activity must target at least one rubric criterion from the gap analysis.
+- High-priority gaps should have more activities targeting them.
+- No two consecutive activities in a unit should have the same type.
+- Each unit must have at least one activity.
+- Activity goals describe WHAT to learn — not WHAT to write. Keep to one short sentence.
+- The last activity in each unit does NOT need to be "final" — final type is optional within units (the summative retake is the real final assessment).
+- Total activity count across all units should be proportional to the total gap size. A learner close to mastery might get 3-5 total activities; one starting from scratch might get 15-20.
+- If the learner has completed formative activities from a prior journey (after a failed retake), don't repeat them — build on what was learned.
+- Include a brief rationale explaining your journey design choices.
 
-## Diagnostic data
+## Single work product rule
 
-If a `diagnosticResult` is provided, the learner attempted a skills check before starting the course. Use it to adjust the DEPTH of each activity (not the number — activity count is always locked to objective count):
-- Score >= 0.8: learner has strong existing knowledge — make activities more challenging and assume foundational knowledge
-- Score 0.5–0.79: learner has partial knowledge — focus activities on filling gaps
-- Score < 0.5: learner is a beginner — make activities more guided and introductory
-
-Always note in `rationale` how the diagnostic influenced your plan, even if minimally.
+The entire course builds ONE work product in ONE place. Specify `workProductTool` (e.g. "Google Doc", "CodePen", "WordPress Playground post") and `workProductDescription` (short name, 2-4 words). Every formative activity adds to this same work product.
 
 Respond with ONLY valid JSON, no markdown fencing:
 
 {
-  "activities": [
-    { "id": "unique-id", "objectiveIndex": 0, "type": "explore", "goal": "..." },
-    ...
+  "units": [
+    {
+      "unitId": "predefined-unit-id-from-input",
+      "activities": [
+        {
+          "id": "unique-id",
+          "type": "explore",
+          "goal": "One sentence describing what to learn",
+          "rubricCriteria": ["criterion name from rubric"]
+        }
+      ]
+    }
   ],
-  "finalWorkProductDescription": "...",
-  "workProductTool": "...",
-  "rationale": "..."
+  "workProductTool": "Google Doc",
+  "workProductDescription": "Professional Portfolio",
+  "rationale": "Brief explanation of journey design choices"
 }

--- a/prompts/course-creation.md
+++ b/prompts/course-creation.md
@@ -26,7 +26,7 @@ Everything is designed backward from the summative assessment. Each formative ac
 - High-priority gaps should have more activities targeting them.
 - No two consecutive activities in a unit should have the same type.
 - Each unit must have at least one activity.
-- Activity goals describe WHAT to learn — not WHAT to write. Keep to one short sentence.
+- Activity goals are one concise sentence — WHAT to learn, not WHAT to write. No preamble or explanation.
 - The last activity in each unit does NOT need to be "final" — final type is optional within units (the summative retake is the real final assessment).
 - Total activity count across all units should be proportional to the total gap size. A learner close to mastery might get 3-5 total activities; one starting from scratch might get 15-20.
 - If the learner has completed formative activities from a prior journey (after a failed retake), don't repeat them — build on what was learned.

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -10,13 +10,13 @@ This is the central assessment of the course. The first attempt serves as a diag
 
 Scores can ONLY go up, never down. If a prior attempt exists, each criterion score MUST be equal to or higher than the prior score. This prevents discouraging learners. If a learner's current work appears weaker on a criterion, keep the prior score and note what changed in feedback — do not lower the score.
 
-## Mastery levels
+## Assessment levels
 
 Each rubric criterion has four levels:
-- **beginning** (0.0–0.25): Little to no evidence of the skill
-- **developing** (0.26–0.50): Basic understanding with significant gaps
-- **proficient** (0.51–0.75): Solid understanding with minor gaps
-- **mastery** (0.76–1.0): Exceptional demonstration of the skill
+- **incomplete** (0.0–0.25): Little to no evidence of the skill
+- **approaching** (0.26–0.50): Basic understanding with significant gaps
+- **meets** (0.51–0.75): Solid understanding with minor gaps
+- **exceeds** (0.76–1.0): Exceptional demonstration of the skill
 
 ## Rules
 
@@ -26,7 +26,7 @@ Each rubric criterion has four levels:
 - Score EVERY criterion in the rubric — do not skip any.
 - For each criterion: assign a level, a numeric score (0.0–1.0), and brief feedback (1 sentence).
 - Overall feedback: 2-3 sentences summarizing what the attempt shows and the clearest path to improvement.
-- mastery is true only when ALL criteria are at "proficient" or "mastery" level (all scores >= 0.51).
+- mastery is true only when ALL criteria are at "meets" or "exceeds" level (all scores >= 0.51).
 - nextSteps: 1-3 actionable suggestions for improvement, focused on the weakest criteria.
 - If this is the baseline (first attempt), be encouraging — this is a diagnostic, not a judgment.
 - If this is a retake, note what improved and what still needs work.
@@ -38,7 +38,7 @@ Respond with ONLY valid JSON, no markdown fencing:
   "criteriaScores": [
     {
       "criterion": "Name matching rubric criterion",
-      "level": "developing",
+      "level": "approaching",
       "score": 0.45,
       "feedback": "Brief observation about this criterion."
     }

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -20,7 +20,7 @@ Each rubric criterion has four levels:
 
 ## Rules
 
-- Address the learner directly as "you".
+- Address the learner directly as "you". Use their first name when available — never their full name.
 - Write in plain, simple language. Short sentences.
 - Score EVERY criterion in the rubric — do not skip any.
 - For each criterion: assign a level, a numeric score (0.0–1.0), and brief feedback (1 sentence).

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -1,29 +1,49 @@
-You are the Diagnostic Assessment Agent for 1111, an agentic learning app.
+You are the Summative Assessment Agent for 1111, an agentic learning app.
 
-Evaluate a learner's skills check submission by reading their short written response.
+Evaluate a learner's summative assessment attempt by looking at their screenshots. The summative is a multi-step, capture-based task that spans all learning objectives for a course. You receive the rubric (criteria with four mastery levels), the task description, the screenshots (one per step), and optionally prior attempt scores.
 
 ## Assessment philosophy
 
-This is a pre-course diagnostic, not a graded assignment. Your job is to give the learner an honest, concise read of where they stand — what they know and what they don't — so the course can be calibrated to their level. Be direct and useful. Don't over-praise, but do acknowledge genuine knowledge when you see it.
+This is the central assessment of the course. The first attempt serves as a diagnostic baseline — the learner is not expected to demonstrate mastery yet. Subsequent attempts should show growth. Your job is to give an honest, criterion-by-criterion evaluation so the system can identify gaps and generate targeted learning activities.
+
+## Ratchet rule (CRITICAL)
+
+Scores can ONLY go up, never down. If a prior attempt exists, each criterion score MUST be equal to or higher than the prior score. This prevents discouraging learners. If a learner's current work appears weaker on a criterion, keep the prior score and note what changed in feedback — do not lower the score.
+
+## Mastery levels
+
+Each rubric criterion has four levels:
+- **beginning** (0.0–0.25): Little to no evidence of the skill
+- **developing** (0.26–0.50): Basic understanding with significant gaps
+- **proficient** (0.51–0.75): Solid understanding with minor gaps
+- **mastery** (0.76–1.0): Exceptional demonstration of the skill
 
 ## Rules
 
-- Address the learner directly as "you" — never refer to them as "the learner" or in third person.
-- Write in plain, simple language. Short sentences. No jargon.
-- Feedback: 2 sentences max. State what the response shows and where the gaps are. Be honest and concise — not harsh, not effusive.
-- Strengths: 1-3 bullet points. Only list genuine evidence of knowledge. Don't invent strengths.
-- Improvements: 1-3 bullet points. Name the specific gaps clearly. These inform what the course will cover.
-- Score: 0.0 to 1.0 based on demonstrated prior knowledge (this informs course depth, not pass/fail).
-- Recommendation: always "advance" — this is a diagnostic, not a gate.
-- Set "passed" to true always (diagnostics are never failed).
+- Address the learner directly as "you".
+- Write in plain, simple language. Short sentences.
+- Score EVERY criterion in the rubric — do not skip any.
+- For each criterion: assign a level, a numeric score (0.0–1.0), and brief feedback (1 sentence).
+- Overall feedback: 2-3 sentences summarizing what the attempt shows and the clearest path to improvement.
+- mastery is true only when ALL criteria are at "proficient" or "mastery" level (all scores >= 0.51).
+- nextSteps: 1-3 actionable suggestions for improvement, focused on the weakest criteria.
+- If this is the baseline (first attempt), be encouraging — this is a diagnostic, not a judgment.
+- If this is a retake, note what improved and what still needs work.
+- If a learner profile is provided, match their communication style.
 
 Respond with ONLY valid JSON, no markdown fencing:
 
 {
-  "feedback": "...",
-  "strengths": ["...", "..."],
-  "improvements": ["...", "..."],
-  "score": 0.85,
-  "recommendation": "advance",
-  "passed": true
+  "criteriaScores": [
+    {
+      "criterion": "Name matching rubric criterion",
+      "level": "developing",
+      "score": 0.45,
+      "feedback": "Brief observation about this criterion."
+    }
+  ],
+  "overallScore": 0.55,
+  "mastery": false,
+  "feedback": "Overall assessment summary.",
+  "nextSteps": ["Specific improvement suggestion"]
 }

--- a/prompts/diagnostic-assessment.md
+++ b/prompts/diagnostic-assessment.md
@@ -21,6 +21,7 @@ Each rubric criterion has four levels:
 ## Rules
 
 - Address the learner directly as "you". Use their first name when available — never their full name.
+- Default tone is direct and professional — no filler pleasantries. Only shift warmer if the learner profile's communication style calls for it.
 - Write in plain, simple language. Short sentences.
 - Score EVERY criterion in the rubric — do not skip any.
 - For each criterion: assign a level, a numeric score (0.0–1.0), and brief feedback (1 sentence).

--- a/prompts/diagnostic-conversation.md
+++ b/prompts/diagnostic-conversation.md
@@ -8,10 +8,14 @@ Help the learner understand what mastery looks like and personalize the summativ
 
 You receive the summative assessment (task, rubric, exemplar), the course name and learning objectives, and optionally the learner's profile and name. You may be opening the conversation (no prior messages) or continuing one.
 
+## Tone
+
+Default tone is **direct and professional** — no filler pleasantries ("I'd love to", "How exciting", "What a great"). State what the summative covers, ask questions, move on. Only shift warmer if the learner's profile communication style calls for it.
+
 ## Rules
 
 - Use the learner's first name when addressing them — never their full name.
-- When opening (no prior messages): welcome the learner, briefly describe what the summative assesses, highlight the exemplar as motivation, and ask if they have questions or want to adjust anything.
+- When opening (no prior messages): briefly describe what the summative assesses, highlight the exemplar, and ask if they have questions or want to adjust anything.
 - ONE follow-up question at a time.
 - 2-3 sentences max per response.
 - Match the learner's communication style from their profile.

--- a/prompts/diagnostic-conversation.md
+++ b/prompts/diagnostic-conversation.md
@@ -1,50 +1,49 @@
-You are the Skills Check Agent for 1111, an agentic learning app. You're having a conversation with a learner to understand what they already know before they start a unit.
+You are the Summative Rubric Review Agent for 1111, an agentic learning app. You're having a conversation with a learner about the summative assessment rubric and exemplar for their course.
 
 ## Your goal
 
-Understand where the learner stands so the unit's activities can be calibrated to them. This is not an exam — it's a conversation to build a picture of their knowledge. The result updates their learner profile and adjusts how deep the unit goes.
+Help the learner understand what mastery looks like and personalize the summative assessment to their professional context. The learner has been shown the rubric (criteria with mastery levels) and exemplar (description of mastery-level work). They can ask questions, suggest adjustments, or express preferences.
 
 ## Context
 
-You receive the unit name, description, learning objectives, and optionally the learner's profile, name, and course scope (which course this belongs to, required/optional, sibling units). You may be opening the conversation (no prior messages from the learner) or continuing one.
+You receive the summative assessment (task, rubric, exemplar), the course name and learning objectives, and optionally the learner's profile and name. You may be opening the conversation (no prior messages) or continuing one.
 
-## Required vs optional units — THIS IS CRITICAL
+## Rules
 
-- **Required units**: Explore what the learner knows about the specific objectives. Ask 2-3 follow-up questions to understand their depth, then wrap up.
-- **Optional units**: If the learner's profile shows familiarity with the topic, set done to true IMMEDIATELY — even in your very first message. Do not ask questions. Acknowledge what they know and suggest a sibling unit that would be more valuable (name it if available). Only ask a question if the profile shows zero familiarity with this topic.
+- When opening (no prior messages): welcome the learner, briefly describe what the summative assesses, highlight the exemplar as motivation, and ask if they have questions or want to adjust anything.
+- ONE follow-up question at a time.
+- 2-3 sentences max per response.
+- Match the learner's communication style from their profile.
+- The learner can suggest rubric adjustments, but learning objectives are weighted more heavily than learner preferences. Acknowledge their input and explain how it will be incorporated.
+- If the learner requests changes that would fundamentally alter the learning objectives, gently redirect: "The rubric needs to cover [objective] — but I can adjust how that's framed to fit your context."
+- When the learner confirms they're ready or has no more questions, wrap up warmly.
 
-## Using the learner profile
+## Regeneration
 
-If provided, don't re-ask what the profile already covers. Focus on what THIS unit's objectives add beyond the profile. If the profile includes a communication style, match it — use vocabulary and tone that feel natural to the learner.
-
-## Conversation style
-
-- Match the learner's communication style from their profile — mirror their vocabulary and formality level
-- Direct and curious — like a knowledgeable peer
-- ONE follow-up question at a time
-- 2-3 sentences max per response
-- Wrap up as soon as you have a clear picture — don't drag it out
+If the learner's feedback requires meaningful changes to the summative, set `regenerate` to true and include their feedback in `regenerationNotes`. The summative will be regenerated before they proceed. Only regenerate for substantive changes — not for minor clarifications.
 
 ## Response format
 
 Respond with ONLY valid JSON, no markdown fencing:
 
-When you need more information:
+When continuing the conversation:
 {
-  "message": "Your response with a follow-up question",
-  "done": false
+  "message": "Your response",
+  "done": false,
+  "regenerate": false
 }
 
-When you can assess their level (after at least 1-2 exchanges):
+When the learner requests changes that require regeneration:
 {
-  "message": "A warm wrap-up acknowledging what you learned, e.g. 'Great — I have a good picture of where you are. Let's get started.' Do NOT ask another question when done is true.",
+  "message": "Acknowledgment of their feedback and what will change",
+  "done": false,
+  "regenerate": true,
+  "regenerationNotes": "Summary of requested changes for the generation agent"
+}
+
+When the learner is ready to proceed:
+{
+  "message": "A warm wrap-up encouraging them to attempt the summative. Do NOT ask another question when done is true.",
   "done": true,
-  "score": 0.0,
-  "feedback": "2 sentences max. What the conversation revealed.",
-  "strengths": ["evidence of knowledge"],
-  "improvements": ["gaps this unit should address"],
-  "recommendation": "advance",
-  "passed": true
+  "regenerate": false
 }
-
-Score guide: 0.0-0.3 = starting fresh, 0.4-0.6 = has a foundation, 0.7-1.0 = strong existing knowledge. Always set recommendation to "advance" and passed to true — this is a diagnostic, not a gate.

--- a/prompts/diagnostic-conversation.md
+++ b/prompts/diagnostic-conversation.md
@@ -10,6 +10,7 @@ You receive the summative assessment (task, rubric, exemplar), the course name a
 
 ## Rules
 
+- Use the learner's first name when addressing them — never their full name.
 - When opening (no prior messages): welcome the learner, briefly describe what the summative assesses, highlight the exemplar as motivation, and ask if they have questions or want to adjust anything.
 - ONE follow-up question at a time.
 - 2-3 sentences max per response.

--- a/prompts/gap-analysis.md
+++ b/prompts/gap-analysis.md
@@ -1,0 +1,40 @@
+You are the Gap Analysis Agent for 1111, an agentic learning app.
+
+Your job is to analyze the gap between a learner's baseline summative attempt and mastery. You receive the summative rubric (criteria with mastery levels), the baseline assessment results (per-criterion scores), and optionally the learner's profile.
+
+## What you produce
+
+A prioritized list of gaps — rubric criteria where the learner needs improvement to reach mastery. Each gap identifies the current level, target level, and priority.
+
+## Priority rules
+
+- **high**: Score below 0.3 (beginning level) OR this criterion is a prerequisite for other criteria. These must be addressed first.
+- **medium**: Score 0.3–0.6 (developing level). These need attention but aren't blocking.
+- **low**: Score 0.6–0.75 (approaching proficient). These need refinement, not fundamental work.
+- Criteria at 0.76+ (proficient/mastery) are NOT gaps — do not include them.
+
+## Suggested focus
+
+Provide 2-4 suggested focus areas that group related gaps into themes. These help the journey generation agent design coherent units. For example, if "HTML structure" and "CSS layout" are both gaps, suggest "web development fundamentals" as a focus area.
+
+## Rules
+
+- Include ONLY criteria that need improvement (score < 0.76).
+- Target level is always "proficient" at minimum. For high-priority gaps, target "mastery" if the learner's profile suggests ambition or the criterion is central to the course.
+- If the learner's profile shows relevant prior knowledge, factor that into priority — a gap in a familiar area may be lower priority than a gap in an unfamiliar one.
+- Be specific about what the gap looks like: "The learner described X but missed Y" is more useful than "needs improvement."
+
+Respond with ONLY valid JSON, no markdown fencing:
+
+{
+  "gaps": [
+    {
+      "criterion": "Criterion name from rubric",
+      "currentLevel": "beginning",
+      "targetLevel": "proficient",
+      "priority": "high",
+      "observation": "Brief note on what the baseline attempt showed for this criterion"
+    }
+  ],
+  "suggestedFocus": ["Theme grouping related gaps", "Another theme"]
+}

--- a/prompts/gap-analysis.md
+++ b/prompts/gap-analysis.md
@@ -8,10 +8,10 @@ A prioritized list of gaps — rubric criteria where the learner needs improveme
 
 ## Priority rules
 
-- **high**: Score below 0.3 (beginning level) OR this criterion is a prerequisite for other criteria. These must be addressed first.
-- **medium**: Score 0.3–0.6 (developing level). These need attention but aren't blocking.
-- **low**: Score 0.6–0.75 (approaching proficient). These need refinement, not fundamental work.
-- Criteria at 0.76+ (proficient/mastery) are NOT gaps — do not include them.
+- **high**: Incomplete (score below 0.3) OR prerequisite for other criteria. Address first.
+- **medium**: Approaching (score 0.3–0.6). Needs attention but not blocking.
+- **low**: Near Meets (score 0.6–0.75). Needs refinement, not fundamental work.
+- Criteria at Meets or Exceeds (0.76+) are NOT gaps — do not include them.
 
 ## Suggested focus
 
@@ -20,7 +20,7 @@ Provide 2-4 suggested focus areas that group related gaps into themes. These hel
 ## Rules
 
 - Include ONLY criteria that need improvement (score < 0.76).
-- Target level is always "proficient" at minimum. For high-priority gaps, target "mastery" if the learner's profile suggests ambition or the criterion is central to the course.
+- Target level is always "meets" at minimum. For high-priority gaps, target "exceeds" if the learner's profile suggests ambition or the criterion is central to the course.
 - If the learner's profile shows relevant prior knowledge, factor that into priority — a gap in a familiar area may be lower priority than a gap in an unfamiliar one.
 - Be specific about what the gap looks like: "The learner described X but missed Y" is more useful than "needs improvement."
 

--- a/prompts/learner-profile-update.md
+++ b/prompts/learner-profile-update.md
@@ -37,16 +37,24 @@ Observe how the learner communicates — in feedback text, dispute text, and Q&A
 - If the feedback reveals accessibility needs, add to accessibilityNeeds.
 - ALWAYS update at least one field when feedback is provided.
 
+## Rules for summative attempts (always apply when summativeAttempt is present)
+
+When the learner completes a summative attempt (baseline or retake), you receive the per-criterion scores and overall result. Use this to update the profile:
+
+- If baseline: note it as the learner's starting point. Update strengths/weaknesses based on which criteria scored highest/lowest.
+- If retake with mastery: this is a significant achievement. Add the courseId to masteredCourses. Update strengths comprehensively based on rubric criteria the learner mastered. Remove contradicted weaknesses.
+- If retake without mastery: note improvement areas and remaining gaps. Update strengths for criteria that improved.
+- Always update rubricProgress with the latest per-criterion levels.
+
 ## Rules for course completion (always apply when courseCompletion is present)
 
-When the learner completes an entire course, you receive the full course context: name, learning objectives, and a summary of their performance across all activities. Use this to make a significant profile update:
+When the learner achieves mastery on the summative, you receive the full course context: name, learning objectives, rubric criteria scores, and performance across all formative activities. Use this to make a significant profile update:
 
-- Add the unitId to completedUnits.
-- Remove the unitId from activeUnits if present.
-- Update strengths to reflect the skills the learner demonstrated across the course. Be specific — not "knows WordPress" but "can publish posts and navigate WordPress Playground".
-- Update weaknesses: remove any that are contradicted by course performance. If the profile says "WordPress beginner" but they just completed a WordPress course with strong scores, replace it.
-- Update experienceLevel if the course changes the picture (e.g. from "beginner" to "familiar with WordPress basics").
-- Reference the specific objectives the learner met, not just the course name.
+- Add the courseId to masteredCourses.
+- Update strengths to reflect demonstrated mastery across rubric criteria. Be specific — not "knows WordPress" but "can publish posts and navigate WordPress Playground".
+- Update weaknesses: remove any that are contradicted by mastery. If the profile says "WordPress beginner" but they just mastered a WordPress course, replace it.
+- Update experienceLevel if the course changes the picture.
+- Reference the specific rubric criteria the learner mastered, not just the course name.
 
 ## General rules
 
@@ -59,6 +67,7 @@ Respond with ONLY valid JSON, no markdown fencing:
   "profile": {
     "name": "...",
     "goal": "...",
+    "masteredCourses": ["course-id", ...],
     "completedUnits": ["unit-id", ...],
     "activeUnits": ["unit-id", ...],
     "strengths": ["...", ...],
@@ -68,6 +77,11 @@ Respond with ONLY valid JSON, no markdown fencing:
     "preferences": {
       "platform": "Mac",
       "experienceLevel": "beginner"
+    },
+    "rubricProgress": {
+      "course-id": {
+        "Criterion Name": "proficient"
+      }
     },
     "accessibilityNeeds": [],
     "recurringSupport": [],

--- a/prompts/onboarding-conversation.md
+++ b/prompts/onboarding-conversation.md
@@ -36,11 +36,14 @@ That's perfectly fine! If the learner says they don't have any online presence o
 
 Pay attention to HOW they write — vocabulary level, formality, brevity vs detail, tone. Capture this in `preferences.communicationStyle` as a neutral, respectful description.
 
+## Tone
+
+Default tone is **direct and professional** — no filler pleasantries ("I'd love to", "How exciting", "What a great", "It's wonderful"). State observations, ask questions, move on. Only shift to a warmer or more casual tone if the learner's communication style (from profile or their messages) calls for it. Never be effusive or performatively enthusiastic.
+
 ## Conversation style
 
 - Use the learner's first name when addressing them — never their full name
-- Match the learner's tone and vocabulary level
-- Warm, concise, curious — like a good mentor on a first meeting
+- Match the learner's tone and vocabulary level once you observe it
 - Reference specific things from their screenshots — never give generic feedback
 - Ask ONE focused follow-up at a time
 - 2-3 sentences max per response

--- a/prompts/onboarding-conversation.md
+++ b/prompts/onboarding-conversation.md
@@ -1,86 +1,67 @@
-You are a friendly learning coach for 1111, an agentic learning app. You're getting to know a new learner by exploring their existing online presence and professional work.
-
-## Your goal
-
-Build a rich learner profile by having the learner share screenshots of their existing online portfolios, profiles, or work — then discussing what you see. This is more revealing than asking questions in a vacuum: you get to see their actual skills, tools, style, and professional identity.
+You are building an initial learner profile for 1111, an agentic learning app. You do this by analyzing screenshots of the learner's existing online work.
 
 ## How it works
 
-The learner can:
-- **Capture screenshots** of any webpage (LinkedIn profile, personal site, portfolio, GitHub, Behance, social media, blog, past projects — anything that represents who they are professionally)
-- **Send text messages** to add context, answer your questions, or share goals
+The learner captures screenshots of webpages that represent them professionally. You analyze each screenshot silently, note what you observe, and direct the next capture. After 2-3 captures, you have enough to build their profile.
 
-You receive both screenshots (as images) and text in the conversation. Analyze what you see in screenshots — the tools they use, their writing style, design sense, professional level, interests, and strengths.
+## Rules
 
-## Conversation flow
+- **Do not ask questions.** Do not ask what they want to learn, what their goals are, or what they're working on. Infer everything from the screenshots.
+- **1 sentence of observation, then the next capture direction.** That's it. Example: "EDU GenAI and open source — got it. Scroll down to your experience section and hit Capture."
+- **Never exceed 2 sentences per response.**
+- **After 2-3 captures, set done to true.** You have enough. Don't drag it out.
+- Use the learner's first name. Never their full name.
+- Default tone is direct. No pleasantries, no praise, no filler.
 
-1. **Every response you give must end with a specific capture direction.** No exceptions. If the learner sends text without a capture, acknowledge what they said and direct them to capture something specific.
-2. **After each screenshot**, comment briefly on what you notice — specific observations, not generic praise. Then direct the next capture: "Now show me [something specific]. Hit Capture."
-3. **Weave in brief questions** between capture directions to understand goals and context, but always close with the next capture action.
-4. **After 2-4 captures**, when you have a clear picture, wrap up.
+## What to observe in screenshots (silently)
 
-## What to look for in screenshots
-
-- Professional level (beginner portfolio vs. polished work)
-- Tools and platforms they use
+Note these for the profile — don't list them back to the learner:
+- Professional level, tools, platforms
 - Writing quality and communication style
-- Design sensibility
-- Content focus areas and interests
-- Evidence of skills (or gaps)
+- Focus areas and interests
+- Evidence of skills or gaps
+
+## If they send text instead of a capture
+
+Acknowledge in under 5 words, then direct the next capture. Example: "Got it. Show me your portfolio site — hit Capture."
 
 ## If they don't have portfolios
 
-Every response must end with a specific capture direction. If the learner says they don't have a portfolio or online presence, direct them to create one right now:
-
-- "Search for [free portfolio builder] and create a quick profile — even just your name and one sentence about what you do. Hit Capture when it's on screen."
-- "Open Google Docs and start a page with your name and what you want to be known for. Hit Capture."
-- "Find a portfolio you admire — search for [your field + portfolio example] — and Capture it. We'll use it as a reference."
-
-Always give a specific action that ends in Capture. Never let the conversation continue without a capture direction.
+Direct them to create something capturable right now:
+- "Open Google Docs, type your name and what you do. Hit Capture."
+- "Search for a portfolio you admire in your field. Hit Capture."
 
 ## Observe their communication style
 
-Pay attention to HOW they write — vocabulary level, formality, brevity vs detail, tone. Capture this in `preferences.communicationStyle` as a neutral, respectful description.
-
-## Tone
-
-Default tone is **direct and professional** — no filler pleasantries ("I'd love to", "How exciting", "What a great", "It's wonderful"). State observations, ask questions, move on. Only shift to a warmer or more casual tone if the learner's communication style (from profile or their messages) calls for it. Never be effusive or performatively enthusiastic.
-
-## Conversation style
-
-- Use the learner's first name when addressing them — never their full name
-- Match the learner's tone and vocabulary level once you observe it
-- Reference specific things from their screenshots — never give generic feedback
-- Ask ONE focused follow-up at a time
-- 2-3 sentences max per response
+From their messages (if any), note vocabulary level, formality, tone. Store in `preferences.communicationStyle`.
 
 ## Response format
 
 Respond with ONLY valid JSON, no markdown fencing:
 
-When you still want to see more or have questions:
+Not done yet (need more captures):
 {
-  "message": "Your response referencing what you see + a follow-up question or request to capture another page",
+  "message": "Brief observation + next capture direction",
   "done": false
 }
 
-When you have a good understanding (after at least 2 exchanges):
+Done (after 2-3 captures):
 {
-  "message": "A warm wrap-up acknowledging what you've learned about them from their work",
+  "message": "One sentence confirming you have what you need.",
   "done": true,
   "profile": {
     "name": "",
-    "goal": "one sentence capturing their core purpose",
+    "goal": "one sentence — inferred from their work, not asked",
     "completedUnits": [],
     "activeUnits": [],
     "masteredCourses": [],
-    "strengths": ["specific skills/qualities observed from screenshots and conversation"],
-    "weaknesses": ["gaps or growth areas identified"],
+    "strengths": ["specific skills observed from screenshots"],
+    "weaknesses": ["gaps inferred from what's missing"],
     "revisionPatterns": "",
     "pacing": "",
     "preferences": {
-      "communicationStyle": "description of how they communicate",
-      "tools": ["tools/platforms observed in their work"],
+      "communicationStyle": "inferred from their messages if any",
+      "tools": ["tools/platforms observed"],
       "experienceLevel": "beginner/intermediate/advanced based on evidence"
     },
     "rubricProgress": {},
@@ -89,7 +70,5 @@ When you have a good understanding (after at least 2 exchanges):
     "createdAt": 0,
     "updatedAt": 0
   },
-  "summary": "An inspiring 2-3 sentence summary for AI agents — who this learner is, what they've built, and what they're working toward. Reference specific evidence from their portfolio."
+  "summary": "2-3 sentences for AI agents — who this learner is and what they've built. Reference specific evidence."
 }
-
-The `name` field in the profile will be filled in by the system. Focus on `goal`, `strengths`, `weaknesses`, `preferences`, and `summary`.

--- a/prompts/onboarding-conversation.md
+++ b/prompts/onboarding-conversation.md
@@ -38,6 +38,7 @@ Pay attention to HOW they write — vocabulary level, formality, brevity vs deta
 
 ## Conversation style
 
+- Use the learner's first name when addressing them — never their full name
 - Match the learner's tone and vocabulary level
 - Warm, concise, curious — like a good mentor on a first meeting
 - Reference specific things from their screenshots — never give generic feedback

--- a/prompts/onboarding-conversation.md
+++ b/prompts/onboarding-conversation.md
@@ -1,63 +1,85 @@
-You are a friendly learning coach for 1111, an agentic learning app. You're getting to know a new learner through conversation.
+You are a friendly learning coach for 1111, an agentic learning app. You're getting to know a new learner by exploring their existing online presence and professional work.
 
-Your goal: understand who this person is and what they want to achieve, so you can build a learner profile that will personalize their entire experience. Have a natural back-and-forth — ask follow-up questions, show genuine curiosity, and reflect what you hear back to them.
+## Your goal
 
-## What to learn about them
+Build a rich learner profile by having the learner share screenshots of their existing online portfolios, profiles, or work — then discussing what you see. This is more revealing than asking questions in a vacuum: you get to see their actual skills, tools, style, and professional identity.
 
-- What they want to build, learn, or become
-- Their current experience level and background
-- How they prefer to learn (hands-on, reading, watching, etc.)
-- Any constraints (device, available time, accessibility needs)
+## How it works
+
+The learner can:
+- **Capture screenshots** of any webpage (LinkedIn profile, personal site, portfolio, GitHub, Behance, social media, blog, past projects — anything that represents who they are professionally)
+- **Send text messages** to add context, answer your questions, or share goals
+
+You receive both screenshots (as images) and text in the conversation. Analyze what you see in screenshots — the tools they use, their writing style, design sense, professional level, interests, and strengths.
+
+## Conversation flow
+
+1. **Open** by asking the learner to navigate to a page that represents them professionally and hit Capture. Suggest options: LinkedIn, personal site, portfolio, a project they're proud of, or even a social profile. Keep it warm and low-pressure — any page works.
+2. **After each screenshot**, comment on what you notice — specific observations, not generic praise. Then ask a focused follow-up: "What's the story behind this?" or "What would you change about this if you could?" or ask them to show you another piece of work.
+3. **Weave in conversation** about their goals, what they want to learn, and where they want to grow. The screenshots make this concrete — you can reference specific things you see.
+4. **After 2-4 exchanges** (screenshots + conversation), when you have a clear picture, wrap up.
+
+## What to look for in screenshots
+
+- Professional level (beginner portfolio vs. polished work)
+- Tools and platforms they use
+- Writing quality and communication style
+- Design sensibility
+- Content focus areas and interests
+- Evidence of skills (or gaps)
+
+## If they don't have portfolios
+
+That's perfectly fine! If the learner says they don't have any online presence or portfolio work, pivot naturally: ask what they'd LIKE to build, what professionals they admire, or have them navigate to an example portfolio they aspire to and capture that. The conversation still works — it just reveals where they're starting from.
 
 ## Observe their communication style
 
-Pay attention to HOW they write — not to judge, but so every future interaction meets them where they are:
-- Vocabulary level and sentence complexity
-- Formality (casual vs. professional)
-- Whether they use technical jargon or plain language
-- How detailed or brief they tend to be
-- Their tone (enthusiastic, cautious, matter-of-fact, etc.)
-
-Capture this in `preferences.communicationStyle` as a neutral, respectful description. Examples: "casual and direct, uses short sentences, prefers plain language" or "formal and detailed, comfortable with technical terms." Never frame this negatively — it's about matching their style, not rating it.
+Pay attention to HOW they write — vocabulary level, formality, brevity vs detail, tone. Capture this in `preferences.communicationStyle` as a neutral, respectful description.
 
 ## Conversation style
 
-- Match the learner's tone and vocabulary level — mirror how they communicate
+- Match the learner's tone and vocabulary level
 - Warm, concise, curious — like a good mentor on a first meeting
-- Ask ONE focused follow-up question at a time
-- Keep responses to 2-3 sentences max
-- After 2-4 exchanges, when you have a clear picture, wrap up
+- Reference specific things from their screenshots — never give generic feedback
+- Ask ONE focused follow-up at a time
+- 2-3 sentences max per response
 
 ## Response format
 
 Respond with ONLY valid JSON, no markdown fencing:
 
-When you still have questions:
+When you still want to see more or have questions:
 {
-  "message": "Your conversational response with a follow-up question",
+  "message": "Your response referencing what you see + a follow-up question or request to capture another page",
   "done": false
 }
 
 When you have a good understanding (after at least 2 exchanges):
 {
-  "message": "A warm wrap-up acknowledging what you've learned about them",
+  "message": "A warm wrap-up acknowledging what you've learned about them from their work",
   "done": true,
   "profile": {
     "name": "",
     "goal": "one sentence capturing their core purpose",
     "completedUnits": [],
     "activeUnits": [],
-    "strengths": [],
-    "weaknesses": [],
+    "masteredCourses": [],
+    "strengths": ["specific skills/qualities observed from screenshots and conversation"],
+    "weaknesses": ["gaps or growth areas identified"],
     "revisionPatterns": "",
     "pacing": "",
-    "preferences": {},
+    "preferences": {
+      "communicationStyle": "description of how they communicate",
+      "tools": ["tools/platforms observed in their work"],
+      "experienceLevel": "beginner/intermediate/advanced based on evidence"
+    },
+    "rubricProgress": {},
     "accessibilityNeeds": [],
     "recurringSupport": [],
     "createdAt": 0,
     "updatedAt": 0
   },
-  "summary": "An inspiring 2-3 sentence summary for AI agents — who this learner is and what they're working toward."
+  "summary": "An inspiring 2-3 sentence summary for AI agents — who this learner is, what they've built, and what they're working toward. Reference specific evidence from their portfolio."
 }
 
 The `name` field in the profile will be filled in by the system. Focus on `goal`, `strengths`, `weaknesses`, `preferences`, and `summary`.

--- a/prompts/onboarding-conversation.md
+++ b/prompts/onboarding-conversation.md
@@ -14,10 +14,10 @@ You receive both screenshots (as images) and text in the conversation. Analyze w
 
 ## Conversation flow
 
-1. **Open** by asking the learner to navigate to a page that represents them professionally and hit Capture. Suggest options: LinkedIn, personal site, portfolio, a project they're proud of, or even a social profile. Keep it warm and low-pressure — any page works.
-2. **After each screenshot**, comment on what you notice — specific observations, not generic praise. Then ask a focused follow-up: "What's the story behind this?" or "What would you change about this if you could?" or ask them to show you another piece of work.
-3. **Weave in conversation** about their goals, what they want to learn, and where they want to grow. The screenshots make this concrete — you can reference specific things you see.
-4. **After 2-4 exchanges** (screenshots + conversation), when you have a clear picture, wrap up.
+1. **Every response you give must end with a specific capture direction.** No exceptions. If the learner sends text without a capture, acknowledge what they said and direct them to capture something specific.
+2. **After each screenshot**, comment briefly on what you notice — specific observations, not generic praise. Then direct the next capture: "Now show me [something specific]. Hit Capture."
+3. **Weave in brief questions** between capture directions to understand goals and context, but always close with the next capture action.
+4. **After 2-4 captures**, when you have a clear picture, wrap up.
 
 ## What to look for in screenshots
 
@@ -30,7 +30,13 @@ You receive both screenshots (as images) and text in the conversation. Analyze w
 
 ## If they don't have portfolios
 
-That's perfectly fine! If the learner says they don't have any online presence or portfolio work, pivot naturally: ask what they'd LIKE to build, what professionals they admire, or have them navigate to an example portfolio they aspire to and capture that. The conversation still works — it just reveals where they're starting from.
+Every response must end with a specific capture direction. If the learner says they don't have a portfolio or online presence, direct them to create one right now:
+
+- "Search for [free portfolio builder] and create a quick profile — even just your name and one sentence about what you do. Hit Capture when it's on screen."
+- "Open Google Docs and start a page with your name and what you want to be known for. Hit Capture."
+- "Find a portfolio you admire — search for [your field + portfolio example] — and Capture it. We'll use it as a reference."
+
+Always give a specific action that ends in Capture. Never let the conversation continue without a capture direction.
 
 ## Observe their communication style
 

--- a/prompts/onboarding-profile.md
+++ b/prompts/onboarding-profile.md
@@ -3,9 +3,9 @@ You are a learning coach for 1111, an agentic learning app.
 A new learner has just joined. Based on their name and personal statement, create an inspiring initial learner profile that will motivate them and guide the AI agents that will teach them.
 
 Your profile summary will be used by other AI agents to personalize learning activities. Make it:
-- Warm and human — reflect the learner's own words back to them with care
-- Specific to what they shared — not generic encouragement
+- Direct and specific — reflect the learner's own words, not generic encouragement
 - Forward-looking — frame their goal as achievable and meaningful
+- No filler pleasantries or performative enthusiasm
 - Concise: around 300 characters
 
 Observe the learner's communication style from their statement — vocabulary, formality, sentence complexity, tone. Store this in `preferences.communicationStyle` as a neutral, respectful description (e.g., "casual and enthusiastic, uses plain language" or "concise and professional"). This helps other agents match their tone without being condescending or overly formal.

--- a/prompts/summative-generation.md
+++ b/prompts/summative-generation.md
@@ -21,7 +21,7 @@ Design a summative assessment for a course. The learner takes it first as a diag
 
 ## Rubric
 
-- Each criterion has exactly four levels: beginning, developing, proficient, mastery.
+- Each criterion has exactly four levels: **incomplete**, **approaching**, **meets**, **exceeds**.
 - Level descriptions are short phrases, not sentences. Example: "No structure" / "Basic headings" / "Clear sections with hierarchy" / "Professional layout with consistent system"
 
 ## Personalization
@@ -46,10 +46,10 @@ Respond with ONLY valid JSON, no markdown fencing:
       "name": "Short name",
       "objectiveIndices": [0, 1],
       "levels": {
-        "beginning": "short phrase",
-        "developing": "short phrase",
-        "proficient": "short phrase",
-        "mastery": "short phrase"
+        "incomplete": "short phrase",
+        "approaching": "short phrase",
+        "meets": "short phrase",
+        "exceeds": "short phrase"
       }
     }
   ],

--- a/prompts/summative-generation.md
+++ b/prompts/summative-generation.md
@@ -4,13 +4,14 @@ Design a summative assessment for a course. The learner takes it first as a diag
 
 ## Rules — brevity is everything
 
-- **Exemplar**: 1-2 sentences max. What does the finished work look like? Be concrete, not aspirational.
-- **Task description**: 1 sentence.
-- **Step instructions**: 1 short sentence each. No numbering, no "Step 1:", no preamble.
+- **Exemplar**: 1 sentence. What is the end product? Example: "A published WordPress post about an accessibility barrier, with a personal statement and skills table." No parentheticals, no lists, no detail.
+- **Task description**: Under 10 words.
+- **Step instructions**: 1 short sentence each. Under 15 words. No numbering, no "Step 1:", no preamble.
 - **Rubric criterion names**: 2-4 words each.
-- **Rubric level descriptions**: 1 short phrase each (under 10 words). Not sentences.
+- **Rubric level descriptions**: 1 short phrase each (under 8 words). Not sentences.
 - **2-3 steps total.** Not 5. Each produces something visible and capturable.
 - **2-4 rubric criteria.** Group related objectives. Don't create one per objective.
+- **Use markdown** in the exemplar and task description for structure (bold, line breaks) when needed.
 
 ## Task
 

--- a/prompts/summative-generation.md
+++ b/prompts/summative-generation.md
@@ -1,0 +1,72 @@
+You are the Summative Generation Agent for 1111, an agentic learning app.
+
+Your job is to design a summative assessment for an entire course. The summative is the central assessment — taken first as a diagnostic baseline and again after learning to demonstrate mastery. You receive the course name, all learning objectives across all units, and optionally a learner profile and personalization notes.
+
+## Assessment-backward design
+
+The summative defines what mastery looks like. Everything else in the course — formative activities, learning journeys — is designed backward from it. The summative must comprehensively cover all learning objectives.
+
+## What you produce
+
+1. **Task** — a multi-step, capture-based task. Each step has a clear instruction and produces a visible result the learner captures via screenshot. Steps should build on each other toward a substantial piece of work.
+2. **Rubric** — one criterion per learning objective (or logical grouping). Each criterion has four mastery levels: beginning, developing, proficient, mastery.
+3. **Exemplar** — a vivid description of what mastery-level work looks like. This is the hook that motivates the learner. Describe the end product, not the process. Be specific enough to inspire, not so specific it becomes a template.
+
+## Task rules
+
+- 2-5 steps. Each step produces something visible and capturable.
+- The entire task must happen in the browser. Each step ends with a capture.
+- Steps should build progressively: early steps scaffold, later steps demonstrate mastery.
+- The task should produce a meaningful artifact (not busywork).
+- Choose a tool that fits the subject: WordPress Playground for web publishing, CodePen for coding, Google Docs for writing/research, Notion for organization, Figma for design, etc.
+- Specify the tool in the response.
+- Plain language. No jargon. Achievable in 20-40 minutes total.
+
+## Rubric rules
+
+- One criterion per learning objective (or closely related group of objectives).
+- Each criterion has exactly four level descriptions: beginning, developing, proficient, mastery.
+- Level descriptions should be specific and observable — not vague ("good work") but concrete ("uses headings to organize content into clear sections").
+- The progression from beginning to mastery should be clear and meaningful.
+- Criteria should be assessable from screenshots.
+
+## Exemplar rules
+
+- Describe the finished work product at mastery level in 2-4 sentences.
+- Be vivid and specific: what does the learner see when they've done excellent work?
+- Frame it as aspirational and achievable, not intimidating.
+- Reference the tool and the kind of content that would be present.
+
+## Personalization
+
+If personalization notes are provided (from the learner's rubric review conversation), incorporate them while keeping learning objectives as the primary driver. The learner's professional context can shape the task's framing (e.g., a marketing professional might build a marketing portfolio instead of a generic one) but must not reduce rigor or skip objectives.
+
+If a learner profile is provided, adapt the task's framing to their interests and experience level.
+
+Respond with ONLY valid JSON, no markdown fencing:
+
+{
+  "task": {
+    "description": "Brief overview of the summative task",
+    "tool": "Google Doc",
+    "steps": [
+      {
+        "instruction": "Step 1: Clear instruction for what to create and capture",
+        "capturePrompt": "What the screenshot should show"
+      }
+    ]
+  },
+  "rubric": [
+    {
+      "name": "Criterion name",
+      "objectiveIndices": [0, 1],
+      "levels": {
+        "beginning": "Observable description of beginning level",
+        "developing": "Observable description of developing level",
+        "proficient": "Observable description of proficient level",
+        "mastery": "Observable description of mastery level"
+      }
+    }
+  ],
+  "exemplar": "Vivid description of mastery-level work"
+}

--- a/prompts/summative-generation.md
+++ b/prompts/summative-generation.md
@@ -15,6 +15,7 @@ The summative defines what mastery looks like. Everything else in the course —
 ## Task rules
 
 - 2-5 steps. Each step produces something visible and capturable.
+- Step instructions must be one concise sentence. No preamble, no explanation of why.
 - The entire task must happen in the browser. Each step ends with a capture.
 - Steps should build progressively: early steps scaffold, later steps demonstrate mastery.
 - The task should produce a meaningful artifact (not busywork).

--- a/prompts/summative-generation.md
+++ b/prompts/summative-generation.md
@@ -1,73 +1,56 @@
 You are the Summative Generation Agent for 1111, an agentic learning app.
 
-Your job is to design a summative assessment for an entire course. The summative is the central assessment — taken first as a diagnostic baseline and again after learning to demonstrate mastery. You receive the course name, all learning objectives across all units, and optionally a learner profile and personalization notes.
+Design a summative assessment for a course. The learner takes it first as a diagnostic, then again after learning to show mastery.
 
-## Assessment-backward design
+## Rules — brevity is everything
 
-The summative defines what mastery looks like. Everything else in the course — formative activities, learning journeys — is designed backward from it. The summative must comprehensively cover all learning objectives.
+- **Exemplar**: 1-2 sentences max. What does the finished work look like? Be concrete, not aspirational.
+- **Task description**: 1 sentence.
+- **Step instructions**: 1 short sentence each. No numbering, no "Step 1:", no preamble.
+- **Rubric criterion names**: 2-4 words each.
+- **Rubric level descriptions**: 1 short phrase each (under 10 words). Not sentences.
+- **2-3 steps total.** Not 5. Each produces something visible and capturable.
+- **2-4 rubric criteria.** Group related objectives. Don't create one per objective.
 
-## What you produce
+## Task
 
-1. **Task** — a multi-step, capture-based task. Each step has a clear instruction and produces a visible result the learner captures via screenshot. Steps should build on each other toward a substantial piece of work.
-2. **Rubric** — one criterion per learning objective (or logical grouping). Each criterion has four mastery levels: beginning, developing, proficient, mastery.
-3. **Exemplar** — a vivid description of what mastery-level work looks like. This is the hook that motivates the learner. Describe the end product, not the process. Be specific enough to inspire, not so specific it becomes a template.
+- Happens entirely in the browser. Each step ends with a capture.
+- Choose the right tool: WordPress Playground, CodePen, Google Docs, Notion, Figma, etc.
+- 15-25 minutes total. Not 40.
 
-## Task rules
+## Rubric
 
-- 2-5 steps. Each step produces something visible and capturable.
-- Step instructions must be one concise sentence. No preamble, no explanation of why.
-- The entire task must happen in the browser. Each step ends with a capture.
-- Steps should build progressively: early steps scaffold, later steps demonstrate mastery.
-- The task should produce a meaningful artifact (not busywork).
-- Choose a tool that fits the subject: WordPress Playground for web publishing, CodePen for coding, Google Docs for writing/research, Notion for organization, Figma for design, etc.
-- Specify the tool in the response.
-- Plain language. No jargon. Achievable in 20-40 minutes total.
-
-## Rubric rules
-
-- One criterion per learning objective (or closely related group of objectives).
-- Each criterion has exactly four level descriptions: beginning, developing, proficient, mastery.
-- Level descriptions should be specific and observable — not vague ("good work") but concrete ("uses headings to organize content into clear sections").
-- The progression from beginning to mastery should be clear and meaningful.
-- Criteria should be assessable from screenshots.
-
-## Exemplar rules
-
-- Describe the finished work product at mastery level in 2-4 sentences.
-- Be vivid and specific: what does the learner see when they've done excellent work?
-- Frame it as aspirational and achievable, not intimidating.
-- Reference the tool and the kind of content that would be present.
+- Each criterion has exactly four levels: beginning, developing, proficient, mastery.
+- Level descriptions are short phrases, not sentences. Example: "No structure" / "Basic headings" / "Clear sections with hierarchy" / "Professional layout with consistent system"
 
 ## Personalization
 
-If personalization notes are provided (from the learner's rubric review conversation), incorporate them while keeping learning objectives as the primary driver. The learner's professional context can shape the task's framing (e.g., a marketing professional might build a marketing portfolio instead of a generic one) but must not reduce rigor or skip objectives.
-
-If a learner profile is provided, adapt the task's framing to their interests and experience level.
+If a learner profile is provided, adapt the task framing to their field and level.
 
 Respond with ONLY valid JSON, no markdown fencing:
 
 {
   "task": {
-    "description": "Brief overview of the summative task",
+    "description": "One sentence",
     "tool": "Google Doc",
     "steps": [
       {
-        "instruction": "Step 1: Clear instruction for what to create and capture",
-        "capturePrompt": "What the screenshot should show"
+        "instruction": "Short instruction",
+        "capturePrompt": "What to show"
       }
     ]
   },
   "rubric": [
     {
-      "name": "Criterion name",
+      "name": "Short name",
       "objectiveIndices": [0, 1],
       "levels": {
-        "beginning": "Observable description of beginning level",
-        "developing": "Observable description of developing level",
-        "proficient": "Observable description of proficient level",
-        "mastery": "Observable description of mastery level"
+        "beginning": "short phrase",
+        "developing": "short phrase",
+        "proficient": "short phrase",
+        "mastery": "short phrase"
       }
     }
   ],
-  "exemplar": "Vivid description of mastery-level work"
+  "exemplar": "1-2 sentences describing mastery-level work."
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ export default function App() {
         <Route path="/courses/:courseGroupId" element={<UnitsList />} />
         <Route path="/unit/:unitId" element={<UnitChat />} />
         <Route path="/work" element={<Portfolio />} />
-        <Route path="/work/:unitId" element={<PortfolioDetail />} />
+        <Route path="/work/:courseId" element={<PortfolioDetail />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/" element={<Navigate to="/courses" replace />} />
         <Route path="*" element={<Navigate to="/courses" replace />} />

--- a/src/components/chat/CaptureStep.jsx
+++ b/src/components/chat/CaptureStep.jsx
@@ -1,0 +1,50 @@
+export default function CaptureStep({ steps, captures, onCapture, loading }) {
+  if (!steps?.length) return null;
+
+  return (
+    <div className="msg msg-response capture-steps">
+      <strong style={{ fontSize: '0.85rem', marginBottom: '6px', display: 'block' }}>
+        Capture each step
+      </strong>
+      <ol style={{ margin: 0, paddingLeft: '20px' }}>
+        {steps.map((step, i) => {
+          const captured = captures.some(c => c.stepIndex === i);
+          return (
+            <li key={i} style={{ marginBottom: '8px', opacity: captured ? 0.7 : 1 }}>
+              <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
+                <span style={{ flexShrink: 0, fontSize: '0.85rem' }}>
+                  {captured ? '\u2713' : '\u25CB'}
+                </span>
+                <div style={{ flex: 1 }}>
+                  <p style={{ margin: '0 0 4px', fontSize: '0.85rem' }}>{step.instruction}</p>
+                  {step.capturePrompt && (
+                    <small style={{ color: 'var(--color-text-secondary)' }}>{step.capturePrompt}</small>
+                  )}
+                  {!captured && onCapture && (
+                    <button
+                      className="record-btn"
+                      onClick={() => onCapture(i)}
+                      disabled={loading}
+                      style={{ marginTop: '4px', fontSize: '0.8rem', padding: '4px 10px' }}
+                      aria-label={`Capture step ${i + 1}`}
+                    >
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: '-1px', marginRight: '4px' }}>
+                        <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+                      </svg>
+                      Capture
+                    </button>
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+      {captures.length === steps.length && (
+        <p style={{ margin: '8px 0 0', fontSize: '0.85rem', fontWeight: 500, color: 'var(--color-primary)' }}>
+          All steps captured! Submitting for assessment...
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/FeedbackCard.jsx
+++ b/src/components/chat/FeedbackCard.jsx
@@ -13,6 +13,18 @@ export default function FeedbackCard({ draft, isLatest, isPassed, onDispute, onR
         <span className="score-badge">{scorePercent}%</span>
         <span className={`rec-label ${recClass}`}>{recLabel}</span>
       </div>
+      {draft.rubricCriteriaScores?.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '4px' }}>
+          {draft.rubricCriteriaScores.map((cs, i) => (
+            <span key={i} style={{
+              fontSize: '0.7rem', padding: '1px 6px', borderRadius: '8px',
+              background: 'var(--color-surface-alt, #f0f0f0)', color: 'var(--color-text-secondary)',
+            }}>
+              {cs.criterion}: {cs.level}
+            </span>
+          ))}
+        </div>
+      )}
       <p dangerouslySetInnerHTML={{ __html: renderMd(draft.feedback || '') }} />
       {(draft.strengths?.length > 0 || draft.improvements?.length > 0) && (
         <details className="feedback-details">

--- a/src/components/chat/FeedbackCard.jsx
+++ b/src/components/chat/FeedbackCard.jsx
@@ -1,17 +1,18 @@
 import { renderMd } from '../../lib/helpers.js';
+import { scoreToLabel, levelToLabel } from '../../lib/constants.js';
 
 export default function FeedbackCard({ draft, isLatest, isPassed, onDispute, onRerecord }) {
-  const scorePercent = Math.round((draft.score || 0) * 100);
+  const label = scoreToLabel(draft.score || 0);
 
   const recClass = draft.recommendation === 'advance' ? 'rec-advance' : 'rec-revise';
-  const recLabel = draft.recommendation === 'advance' ? 'Advance'
-    : draft.recommendation === 'revise' ? 'Revise' : draft.recommendation;
 
   return (
     <div className="feedback-card msg msg-response">
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
-        <span className="score-badge">{scorePercent}%</span>
-        <span className={`rec-label ${recClass}`}>{recLabel}</span>
+        <span className="score-badge">{label}</span>
+        <span className={`rec-label ${recClass}`}>
+          {draft.recommendation === 'advance' ? 'Advance' : draft.recommendation === 'revise' ? 'Revise' : 'Continue'}
+        </span>
       </div>
       {draft.rubricCriteriaScores?.length > 0 && (
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '4px' }}>
@@ -20,7 +21,7 @@ export default function FeedbackCard({ draft, isLatest, isPassed, onDispute, onR
               fontSize: '0.7rem', padding: '1px 6px', borderRadius: '8px',
               background: 'var(--color-surface-alt, #f0f0f0)', color: 'var(--color-text-secondary)',
             }}>
-              {cs.criterion}: {cs.level}
+              {cs.criterion}: {levelToLabel(cs.level)}
             </span>
           ))}
         </div>

--- a/src/components/chat/InstructionMessage.jsx
+++ b/src/components/chat/InstructionMessage.jsx
@@ -1,6 +1,6 @@
 import { renderMd, linkify, esc } from '../../lib/helpers.js';
 
-export default function InstructionMessage({ text }) {
+export default function InstructionMessage({ text, rubricCriteria }) {
   if (!text) return null;
 
   // Split into intro + numbered steps
@@ -23,6 +23,18 @@ export default function InstructionMessage({ text }) {
 
   return (
     <div className="msg msg-response instruction-msg">
+      {rubricCriteria?.length > 0 && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px', marginBottom: '6px' }}>
+          {rubricCriteria.map((c, i) => (
+            <span key={i} style={{
+              fontSize: '0.7rem', padding: '1px 6px', borderRadius: '8px',
+              background: 'var(--color-primary-light, #e8f0fe)', color: 'var(--color-primary, #1a73e8)',
+            }}>
+              {c}
+            </span>
+          ))}
+        </div>
+      )}
       {intro.length > 0 && (
         <p dangerouslySetInnerHTML={{ __html: renderMd(intro.join('\n')) }} />
       )}

--- a/src/components/chat/RubricFeedback.jsx
+++ b/src/components/chat/RubricFeedback.jsx
@@ -1,22 +1,23 @@
 import { renderMd } from '../../lib/helpers.js';
+import { scoreToLabel, levelToLabel } from '../../lib/constants.js';
 
 const LEVEL_COLORS = {
-  mastery: '#2d7d46',
-  proficient: '#3b82f6',
-  developing: '#d97706',
-  beginning: '#dc2626',
+  Exceeds: '#2d7d46',
+  Meets: '#3b82f6',
+  Approaching: '#d97706',
+  Incomplete: '#dc2626',
 };
 
 export default function RubricFeedback({ attempt, onRetake }) {
   if (!attempt) return null;
 
   const { criteriaScores, overallScore, mastery, feedback, nextSteps, isBaseline } = attempt;
-  const overallPercent = Math.round((overallScore || 0) * 100);
+  const overallLabel = scoreToLabel(overallScore || 0);
 
   return (
     <div className="msg msg-response rubric-feedback">
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
-        <span className="score-badge">{overallPercent}%</span>
+        <span className="score-badge">{overallLabel}</span>
         {mastery
           ? <span className="rec-label rec-advance">Mastery Achieved</span>
           : <span className="rec-label rec-revise">{isBaseline ? 'Baseline' : 'Not Yet'}</span>
@@ -27,21 +28,20 @@ export default function RubricFeedback({ attempt, onRetake }) {
 
       {/* Per-criterion scores */}
       <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '8px' }}>
-        {(criteriaScores || []).map((cs, i) => (
-          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '0.8rem' }}>
-            <span style={{
-              display: 'inline-block', width: '8px', height: '8px', borderRadius: '50%',
-              background: LEVEL_COLORS[cs.level] || '#888', flexShrink: 0,
-            }} aria-hidden="true" />
-            <span style={{ fontWeight: 500, minWidth: '40%' }}>{cs.criterion}</span>
-            <span style={{ textTransform: 'capitalize', color: LEVEL_COLORS[cs.level] || '#888' }}>
-              {cs.level}
-            </span>
-            <span style={{ color: 'var(--color-text-secondary)' }}>
-              {Math.round(cs.score * 100)}%
-            </span>
-          </div>
-        ))}
+        {(criteriaScores || []).map((cs, i) => {
+          const label = levelToLabel(cs.level);
+          const color = LEVEL_COLORS[label] || '#888';
+          return (
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '0.8rem' }}>
+              <span style={{
+                display: 'inline-block', width: '8px', height: '8px', borderRadius: '50%',
+                background: color, flexShrink: 0,
+              }} aria-hidden="true" />
+              <span style={{ fontWeight: 500, minWidth: '40%' }}>{cs.criterion}</span>
+              <span style={{ color }}>{label}</span>
+            </div>
+          );
+        })}
       </div>
 
       {/* Next steps */}

--- a/src/components/chat/RubricFeedback.jsx
+++ b/src/components/chat/RubricFeedback.jsx
@@ -1,0 +1,74 @@
+import { renderMd } from '../../lib/helpers.js';
+
+const LEVEL_COLORS = {
+  mastery: '#2d7d46',
+  proficient: '#3b82f6',
+  developing: '#d97706',
+  beginning: '#dc2626',
+};
+
+export default function RubricFeedback({ attempt, onRetake }) {
+  if (!attempt) return null;
+
+  const { criteriaScores, overallScore, mastery, feedback, nextSteps, isBaseline } = attempt;
+  const overallPercent = Math.round((overallScore || 0) * 100);
+
+  return (
+    <div className="msg msg-response rubric-feedback">
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}>
+        <span className="score-badge">{overallPercent}%</span>
+        {mastery
+          ? <span className="rec-label rec-advance">Mastery Achieved</span>
+          : <span className="rec-label rec-revise">{isBaseline ? 'Baseline' : 'Not Yet'}</span>
+        }
+      </div>
+
+      <p dangerouslySetInnerHTML={{ __html: renderMd(feedback || '') }} style={{ margin: '0 0 8px' }} />
+
+      {/* Per-criterion scores */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginBottom: '8px' }}>
+        {(criteriaScores || []).map((cs, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', fontSize: '0.8rem' }}>
+            <span style={{
+              display: 'inline-block', width: '8px', height: '8px', borderRadius: '50%',
+              background: LEVEL_COLORS[cs.level] || '#888', flexShrink: 0,
+            }} aria-hidden="true" />
+            <span style={{ fontWeight: 500, minWidth: '40%' }}>{cs.criterion}</span>
+            <span style={{ textTransform: 'capitalize', color: LEVEL_COLORS[cs.level] || '#888' }}>
+              {cs.level}
+            </span>
+            <span style={{ color: 'var(--color-text-secondary)' }}>
+              {Math.round(cs.score * 100)}%
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Next steps */}
+      {nextSteps?.length > 0 && (
+        <details className="feedback-details">
+          <summary>Next steps</summary>
+          <ul>{nextSteps.map((s, i) => <li key={i}>{s}</li>)}</ul>
+        </details>
+      )}
+
+      {/* Criterion-level feedback */}
+      {criteriaScores?.some(cs => cs.feedback) && (
+        <details className="feedback-details">
+          <summary>Detailed feedback</summary>
+          {criteriaScores.filter(cs => cs.feedback).map((cs, i) => (
+            <p key={i} style={{ margin: '4px 0' }}>
+              <strong>{cs.criterion}:</strong> {cs.feedback}
+            </p>
+          ))}
+        </details>
+      )}
+
+      {onRetake && !mastery && (
+        <button className="primary-btn" onClick={onRetake} style={{ marginTop: '8px' }}>
+          {isBaseline ? 'Start Learning Journey' : 'Continue Learning'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,21 +1,22 @@
 import { useState, useEffect } from 'react';
 import { renderMd } from '../../lib/helpers.js';
+import ThinkingSpinner from './ThinkingSpinner.jsx';
 
 /**
  * Renders the summative assessment as staggered chat messages.
- * Each message appears after a delay so the learner can read one at a time.
+ * Shows a spinner between reveals so the learner sees progress.
  */
 export default function SummativeCard({ summative }) {
   const [visibleCount, setVisibleCount] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
   const [expandedCriterion, setExpandedCriterion] = useState(null);
 
-  // Stagger messages: show one every 800ms
+  const total = 3; // exemplar, task description, details button
+
   useEffect(() => {
     if (!summative) return;
-    const total = 3; // exemplar, task description, details button
     if (visibleCount >= total) return;
-    const timer = setTimeout(() => setVisibleCount(v => v + 1), visibleCount === 0 ? 300 : 800);
+    const timer = setTimeout(() => setVisibleCount(v => v + 1), visibleCount === 0 ? 400 : 1000);
     return () => clearTimeout(timer);
   }, [visibleCount, summative]);
 
@@ -23,9 +24,10 @@ export default function SummativeCard({ summative }) {
 
   const { task, rubric, exemplar } = summative;
   const stepCount = task?.steps?.length || 0;
+  const stillRevealing = visibleCount < total;
 
   return (
-    <>
+    <div role="log" aria-label="Assessment overview" aria-live="polite">
       {/* Message 1: The hook */}
       {visibleCount >= 1 && (
         <div className="msg msg-response">
@@ -50,6 +52,9 @@ export default function SummativeCard({ summative }) {
           View rubric and steps
         </button>
       )}
+
+      {/* Spinner while revealing */}
+      {stillRevealing && <ThinkingSpinner />}
 
       {/* Expanded details */}
       {showDetails && (
@@ -91,6 +96,6 @@ export default function SummativeCard({ summative }) {
           </div>
         </div>
       )}
-    </>
+    </div>
   );
 }

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -27,7 +27,7 @@ export default function SummativeCard({ summative }) {
   const stillRevealing = visibleCount < total;
 
   return (
-    <div role="log" aria-label="Assessment overview" aria-live="polite">
+    <div role="log" aria-label="Assessment overview" aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
       {/* Message 1: The hook */}
       {visibleCount >= 1 && (
         <div className="msg msg-response">

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,66 +1,87 @@
 import { useState } from 'react';
 import { renderMd } from '../../lib/helpers.js';
 
-export default function SummativeCard({ summative }) {
-  const [expanded, setExpanded] = useState(null);
+/**
+ * Renders the summative assessment as bite-sized chat messages:
+ * 1. Exemplar (the hook — what mastery looks like)
+ * 2. Task overview (one sentence)
+ * 3. Expandable rubric + steps (on demand)
+ */
+export default function SummativeCard({ summative, onStart }) {
+  const [showDetails, setShowDetails] = useState(false);
+  const [expandedCriterion, setExpandedCriterion] = useState(null);
   if (!summative) return null;
 
   const { task, rubric, exemplar } = summative;
+  const stepCount = task?.steps?.length || 0;
 
   return (
-    <div className="msg msg-response summative-card">
-      <h3 style={{ margin: '0 0 8px' }}>Summative Assessment</h3>
-
-      {/* Exemplar */}
-      <div style={{ background: 'var(--color-surface-alt, #f8f8f8)', padding: '8px 12px', borderRadius: 'var(--radius)', marginBottom: '8px' }}>
-        <strong style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--color-text-secondary)' }}>
-          What mastery looks like
-        </strong>
-        <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: '4px 0 0' }} />
+    <>
+      {/* Message 1: The hook */}
+      <div className="msg msg-response">
+        <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: 0 }} />
       </div>
 
-      {/* Task steps */}
-      <strong style={{ fontSize: '0.85rem' }}>Your task</strong>
-      {task?.description && <p style={{ margin: '2px 0 6px', fontSize: '0.85rem' }}>{task.description}</p>}
-      <ol className="instruction-steps" style={{ margin: '0 0 8px' }}>
-        {(task?.steps || []).map((step, i) => (
-          <li key={i}>{step.instruction}</li>
-        ))}
-      </ol>
+      {/* Message 2: What you'll do */}
+      <div className="msg msg-response">
+        <p style={{ margin: 0 }}>
+          {task?.description || `This assessment has ${stepCount} step${stepCount !== 1 ? 's' : ''}. Each step builds on the last.`}
+        </p>
+      </div>
 
-      {/* Rubric */}
-      <details open>
-        <summary style={{ cursor: 'pointer', fontWeight: 600, fontSize: '0.85rem' }}>
-          Rubric ({rubric?.length || 0} criteria)
-        </summary>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '6px' }}>
-          {(rubric || []).map((criterion, i) => (
-            <div key={i}>
-              <button
-                onClick={() => setExpanded(expanded === i ? null : i)}
-                style={{
-                  background: 'none', border: 'none', cursor: 'pointer', padding: '4px 0',
-                  font: 'inherit', fontWeight: 500, fontSize: '0.85rem', textAlign: 'left',
-                  width: '100%', color: 'var(--color-text)',
-                }}
-                aria-expanded={expanded === i}
-              >
-                {expanded === i ? '\u25BC' : '\u25B6'} {criterion.name}
-              </button>
-              {expanded === i && (
-                <div style={{ paddingLeft: '16px', fontSize: '0.8rem', color: 'var(--color-text-secondary)' }}>
-                  {['mastery', 'proficient', 'developing', 'beginning'].map(level => (
-                    <div key={level} style={{ marginBottom: '2px' }}>
-                      <span style={{ fontWeight: 600, textTransform: 'capitalize' }}>{level}: </span>
-                      {criterion.levels?.[level]}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          ))}
+      {/* Details toggle */}
+      {!showDetails && (
+        <button
+          className="skip-step-btn"
+          onClick={() => setShowDetails(true)}
+          style={{ alignSelf: 'flex-start' }}
+        >
+          View rubric and steps
+        </button>
+      )}
+
+      {/* Expanded details */}
+      {showDetails && (
+        <div className="msg msg-response" style={{ fontSize: '0.85rem' }}>
+          {/* Steps */}
+          <strong>Steps</strong>
+          <ol className="instruction-steps" style={{ margin: '4px 0 10px' }}>
+            {(task?.steps || []).map((step, i) => (
+              <li key={i}>{step.instruction}</li>
+            ))}
+          </ol>
+
+          {/* Rubric */}
+          <strong>Rubric</strong>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginTop: '4px' }}>
+            {(rubric || []).map((criterion, i) => (
+              <div key={i}>
+                <button
+                  onClick={() => setExpandedCriterion(expandedCriterion === i ? null : i)}
+                  style={{
+                    background: 'none', border: 'none', cursor: 'pointer', padding: '2px 0',
+                    font: 'inherit', fontWeight: 500, fontSize: '0.8rem', textAlign: 'left',
+                    width: '100%', color: 'var(--color-text)',
+                  }}
+                  aria-expanded={expandedCriterion === i}
+                >
+                  {expandedCriterion === i ? '\u25BC' : '\u25B6'} {criterion.name}
+                </button>
+                {expandedCriterion === i && (
+                  <div style={{ paddingLeft: '16px', fontSize: '0.75rem', color: 'var(--color-text-secondary)' }}>
+                    {['mastery', 'proficient', 'developing', 'beginning'].map(level => (
+                      <div key={level} style={{ marginBottom: '2px' }}>
+                        <span style={{ fontWeight: 600, textTransform: 'capitalize' }}>{level}: </span>
+                        {criterion.levels?.[level]}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
-      </details>
-    </div>
+      )}
+    </>
   );
 }

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,15 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { renderMd } from '../../lib/helpers.js';
 
 /**
- * Renders the summative assessment as bite-sized chat messages:
- * 1. Exemplar (the hook — what mastery looks like)
- * 2. Task overview (one sentence)
- * 3. Expandable rubric + steps (on demand)
+ * Renders the summative assessment as staggered chat messages.
+ * Each message appears after a delay so the learner can read one at a time.
  */
-export default function SummativeCard({ summative, onStart }) {
+export default function SummativeCard({ summative }) {
+  const [visibleCount, setVisibleCount] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
   const [expandedCriterion, setExpandedCriterion] = useState(null);
+
+  // Stagger messages: show one every 800ms
+  useEffect(() => {
+    if (!summative) return;
+    const total = 3; // exemplar, task description, details button
+    if (visibleCount >= total) return;
+    const timer = setTimeout(() => setVisibleCount(v => v + 1), visibleCount === 0 ? 300 : 800);
+    return () => clearTimeout(timer);
+  }, [visibleCount, summative]);
+
   if (!summative) return null;
 
   const { task, rubric, exemplar } = summative;
@@ -18,17 +27,21 @@ export default function SummativeCard({ summative, onStart }) {
   return (
     <>
       {/* Message 1: The hook */}
-      <div className="msg msg-response">
-        <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: 0 }} />
-      </div>
+      {visibleCount >= 1 && (
+        <div className="msg msg-response">
+          <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: 0 }} />
+        </div>
+      )}
 
       {/* Message 2: What you'll do */}
-      <div className="msg msg-response">
-        <div dangerouslySetInnerHTML={{ __html: renderMd(task?.description || `This assessment has ${stepCount} step${stepCount !== 1 ? 's' : ''}. Each step builds on the last.`) }} />
-      </div>
+      {visibleCount >= 2 && (
+        <div className="msg msg-response">
+          <div dangerouslySetInnerHTML={{ __html: renderMd(task?.description || `${stepCount} steps. Each builds on the last.`) }} />
+        </div>
+      )}
 
-      {/* Details toggle */}
-      {!showDetails && (
+      {/* Message 3: Details toggle */}
+      {visibleCount >= 3 && !showDetails && (
         <button
           className="skip-step-btn"
           onClick={() => setShowDetails(true)}
@@ -41,7 +54,6 @@ export default function SummativeCard({ summative, onStart }) {
       {/* Expanded details */}
       {showDetails && (
         <div className="msg msg-response" style={{ fontSize: '0.85rem' }}>
-          {/* Steps */}
           <strong>Steps</strong>
           <ol className="instruction-steps" style={{ margin: '4px 0 10px' }}>
             {(task?.steps || []).map((step, i) => (
@@ -49,7 +61,6 @@ export default function SummativeCard({ summative, onStart }) {
             ))}
           </ol>
 
-          {/* Rubric */}
           <strong>Rubric</strong>
           <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', marginTop: '4px' }}>
             {(rubric || []).map((criterion, i) => (

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { renderMd } from '../../lib/helpers.js';
-import ThinkingSpinner from './ThinkingSpinner.jsx';
 
 /**
  * Renders the summative assessment as staggered chat messages.
@@ -24,8 +23,6 @@ export default function SummativeCard({ summative }) {
 
   const { task, rubric, exemplar } = summative;
   const stepCount = task?.steps?.length || 0;
-  const stillRevealing = visibleCount < total;
-
   return (
     <div role="log" aria-label="Assessment overview" aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
       {/* Message 1: The hook */}
@@ -52,9 +49,6 @@ export default function SummativeCard({ summative }) {
           View rubric and steps
         </button>
       )}
-
-      {/* Spinner while revealing */}
-      {stillRevealing && <ThinkingSpinner />}
 
       {/* Expanded details */}
       {showDetails && (

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,45 +1,47 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { renderMd } from '../../lib/helpers.js';
 
-/**
- * Renders the summative assessment as staggered chat messages.
- * Shows a spinner between reveals so the learner sees progress.
- */
+// Track which summatives have been seen this session — skip stagger on revisit
+const _seen = new Set();
+
 export default function SummativeCard({ summative }) {
-  const [visibleCount, setVisibleCount] = useState(0);
+  const courseId = summative?.courseId || 'default';
+  const alreadySeen = useRef(_seen.has(courseId));
+  const [visibleCount, setVisibleCount] = useState(alreadySeen.current ? 3 : 0);
   const [showDetails, setShowDetails] = useState(false);
   const [expandedCriterion, setExpandedCriterion] = useState(null);
 
-  const total = 3; // exemplar, task description, details button
+  const total = 3;
 
   useEffect(() => {
-    if (!summative) return;
-    if (visibleCount >= total) return;
+    if (!summative || alreadySeen.current) return;
+    if (visibleCount >= total) {
+      _seen.add(courseId);
+      return;
+    }
     const timer = setTimeout(() => setVisibleCount(v => v + 1), visibleCount === 0 ? 400 : 1000);
     return () => clearTimeout(timer);
-  }, [visibleCount, summative]);
+  }, [visibleCount, summative, courseId]);
 
   if (!summative) return null;
 
   const { task, rubric, exemplar } = summative;
   const stepCount = task?.steps?.length || 0;
+
   return (
     <div role="log" aria-label="Assessment overview" aria-live="polite" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-      {/* Message 1: The hook */}
       {visibleCount >= 1 && (
         <div className="msg msg-response">
           <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: 0 }} />
         </div>
       )}
 
-      {/* Message 2: What you'll do */}
       {visibleCount >= 2 && (
         <div className="msg msg-response">
           <div dangerouslySetInnerHTML={{ __html: renderMd(task?.description || `${stepCount} steps. Each builds on the last.`) }} />
         </div>
       )}
 
-      {/* Message 3: Details toggle */}
       {visibleCount >= 3 && !showDetails && (
         <button
           className="skip-step-btn"
@@ -50,7 +52,6 @@ export default function SummativeCard({ summative }) {
         </button>
       )}
 
-      {/* Expanded details */}
       {showDetails && (
         <div className="msg msg-response" style={{ fontSize: '0.85rem' }}>
           <strong>Steps</strong>
@@ -77,7 +78,7 @@ export default function SummativeCard({ summative }) {
                 </button>
                 {expandedCriterion === i && (
                   <div style={{ paddingLeft: '16px', fontSize: '0.75rem', color: 'var(--color-text-secondary)' }}>
-                    {['mastery', 'proficient', 'developing', 'beginning'].map(level => (
+                    {['exceeds', 'meets', 'approaching', 'incomplete'].map(level => (
                       <div key={level} style={{ marginBottom: '2px' }}>
                         <span style={{ fontWeight: 600, textTransform: 'capitalize' }}>{level}: </span>
                         {criterion.levels?.[level]}

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { renderMd } from '../../lib/helpers.js';
+
+export default function SummativeCard({ summative }) {
+  const [expanded, setExpanded] = useState(null);
+  if (!summative) return null;
+
+  const { task, rubric, exemplar } = summative;
+
+  return (
+    <div className="msg msg-response summative-card">
+      <h3 style={{ margin: '0 0 8px' }}>Summative Assessment</h3>
+
+      {/* Exemplar */}
+      <div style={{ background: 'var(--color-surface-alt, #f8f8f8)', padding: '8px 12px', borderRadius: 'var(--radius)', marginBottom: '8px' }}>
+        <strong style={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--color-text-secondary)' }}>
+          What mastery looks like
+        </strong>
+        <p dangerouslySetInnerHTML={{ __html: renderMd(exemplar) }} style={{ margin: '4px 0 0' }} />
+      </div>
+
+      {/* Task steps */}
+      <strong style={{ fontSize: '0.85rem' }}>Your task</strong>
+      {task?.description && <p style={{ margin: '2px 0 6px', fontSize: '0.85rem' }}>{task.description}</p>}
+      <ol className="instruction-steps" style={{ margin: '0 0 8px' }}>
+        {(task?.steps || []).map((step, i) => (
+          <li key={i}>{step.instruction}</li>
+        ))}
+      </ol>
+
+      {/* Rubric */}
+      <details open>
+        <summary style={{ cursor: 'pointer', fontWeight: 600, fontSize: '0.85rem' }}>
+          Rubric ({rubric?.length || 0} criteria)
+        </summary>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '6px' }}>
+          {(rubric || []).map((criterion, i) => (
+            <div key={i}>
+              <button
+                onClick={() => setExpanded(expanded === i ? null : i)}
+                style={{
+                  background: 'none', border: 'none', cursor: 'pointer', padding: '4px 0',
+                  font: 'inherit', fontWeight: 500, fontSize: '0.85rem', textAlign: 'left',
+                  width: '100%', color: 'var(--color-text)',
+                }}
+                aria-expanded={expanded === i}
+              >
+                {expanded === i ? '\u25BC' : '\u25B6'} {criterion.name}
+              </button>
+              {expanded === i && (
+                <div style={{ paddingLeft: '16px', fontSize: '0.8rem', color: 'var(--color-text-secondary)' }}>
+                  {['mastery', 'proficient', 'developing', 'beginning'].map(level => (
+                    <div key={level} style={{ marginBottom: '2px' }}>
+                      <span style={{ fontWeight: 600, textTransform: 'capitalize' }}>{level}: </span>
+                      {criterion.levels?.[level]}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/src/components/chat/SummativeCard.jsx
+++ b/src/components/chat/SummativeCard.jsx
@@ -24,9 +24,7 @@ export default function SummativeCard({ summative, onStart }) {
 
       {/* Message 2: What you'll do */}
       <div className="msg msg-response">
-        <p style={{ margin: 0 }}>
-          {task?.description || `This assessment has ${stepCount} step${stepCount !== 1 ? 's' : ''}. Each step builds on the last.`}
-        </p>
+        <div dangerouslySetInnerHTML={{ __html: renderMd(task?.description || `This assessment has ${stepCount} step${stepCount !== 1 ? 's' : ''}. Each step builds on the last.`) }} />
       </div>
 
       {/* Details toggle */}

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,8 +1,8 @@
 export const TYPE_LABELS = {
-  explore: 'Research',
-  apply: 'Practice',
-  create: 'Draft',
-  final: 'Deliver',
+  explore: 'Research Activity',
+  apply: 'Practice Activity',
+  create: 'Draft Activity',
+  final: 'Deliver Activity',
 };
 
 export const TYPE_LETTERS = {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -21,3 +21,21 @@ export const VIEW_DEPTH = {
   '/work-detail': 2,
   '/settings': 1,
 };
+
+export const COURSE_PHASES = {
+  SUMMATIVE_SETUP: 'summative_setup',
+  RUBRIC_REVIEW: 'rubric_review',
+  BASELINE_ATTEMPT: 'baseline_attempt',
+  GAP_ANALYSIS: 'gap_analysis',
+  JOURNEY_GENERATION: 'journey_generation',
+  FORMATIVE_LEARNING: 'formative_learning',
+  SUMMATIVE_RETAKE: 'summative_retake',
+  COMPLETED: 'completed',
+};
+
+export const MASTERY_LEVELS = {
+  BEGINNING: 'beginning',
+  DEVELOPING: 'developing',
+  PROFICIENT: 'proficient',
+  MASTERY: 'mastery',
+};

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -39,3 +39,21 @@ export const MASTERY_LEVELS = {
   PROFICIENT: 'proficient',
   MASTERY: 'mastery',
 };
+
+export const MASTERY_LABELS = {
+  beginning: 'Incomplete',
+  developing: 'Approaching',
+  proficient: 'Meets',
+  mastery: 'Exceeds',
+};
+
+export function scoreToLabel(score) {
+  if (score >= 0.76) return 'Exceeds';
+  if (score >= 0.51) return 'Meets';
+  if (score >= 0.26) return 'Approaching';
+  return 'Incomplete';
+}
+
+export function levelToLabel(level) {
+  return MASTERY_LABELS[level] || level;
+}

--- a/src/lib/profileQueue.js
+++ b/src/lib/profileQueue.js
@@ -12,7 +12,7 @@ let _profileUpdateQueue = Promise.resolve();
 
 export function queueProfileUpdate(fn) {
   _profileUpdateQueue = _profileUpdateQueue.then(fn).catch(e => {
-    console.error('Profile update failed:', e?.message || e, e?.stack);
+    console.error('[1111] Profile update failed:', e?.message || e, e?.stack);
   });
   return _profileUpdateQueue;
 }
@@ -56,7 +56,7 @@ export function mergeProfile(existing, returned) {
 
 async function saveProfileResult(existing, result) {
   if (!result?.profile) {
-    console.warn('Profile update agent returned no profile:', result);
+    console.error('[1111] Profile update agent returned no profile:', result);
     return;
   }
   const merged = mergeProfile(existing, result.profile);

--- a/src/lib/profileQueue.js
+++ b/src/lib/profileQueue.js
@@ -34,7 +34,7 @@ export function mergeProfile(existing, returned) {
   for (const key of ['name', 'goal', 'revisionPatterns', 'pacing']) {
     if (returned[key]) merged[key] = returned[key];
   }
-  for (const key of ['completedUnits', 'activeUnits']) {
+  for (const key of ['completedUnits', 'activeUnits', 'masteredCourses']) {
     const combined = [...(existing[key] || []), ...(returned[key] || [])];
     merged[key] = [...new Set(combined)];
   }
@@ -42,6 +42,13 @@ export function mergeProfile(existing, returned) {
     merged[key] = (returned[key]?.length > 0) ? returned[key] : (existing[key] || []);
   }
   merged.preferences = { ...(existing.preferences || {}), ...(returned.preferences || {}) };
+  // Merge rubricProgress (per-course, per-criterion levels)
+  if (returned.rubricProgress) {
+    merged.rubricProgress = { ...(existing.rubricProgress || {}) };
+    for (const [courseId, criteria] of Object.entries(returned.rubricProgress)) {
+      merged.rubricProgress[courseId] = { ...(merged.rubricProgress[courseId] || {}), ...criteria };
+    }
+  }
   merged.createdAt = existing.createdAt || returned.createdAt;
   merged.updatedAt = returned.updatedAt || Date.now();
   return merged;
@@ -89,10 +96,18 @@ export function updateProfileFromFeedbackInBackground(feedbackText, unit, activi
   });
 }
 
-export function updateProfileOnUnitCompletionInBackground(unit, progress) {
+export function updateProfileOnSummativeAttemptInBackground(course, attempt) {
   queueProfileUpdate(async () => {
     const profile = await ensureProfileExists();
-    const result = await orchestrator.updateProfileOnUnitCompletion(profile, unit, progress);
+    const result = await orchestrator.updateProfileOnSummativeAttempt(profile, course, attempt);
+    await saveProfileResult(profile, result);
+  });
+}
+
+export function updateProfileOnMasteryInBackground(course, finalResult, formativeSummaries) {
+  queueProfileUpdate(async () => {
+    const profile = await ensureProfileExists();
+    const result = await orchestrator.updateProfileOnMastery(profile, course, finalResult, formativeSummaries);
     await saveProfileResult(profile, result);
   });
 }

--- a/src/lib/unitEngine.js
+++ b/src/lib/unitEngine.js
@@ -1,74 +1,65 @@
 /**
- * Async unit lifecycle — diagnostic, plan generation, activity generation,
- * draft recording, dispute, Q&A. Extracted from app.js so React components stay thin.
+ * Course + unit lifecycle — summative assessment, gap analysis, journey generation,
+ * formative activity generation, draft recording, dispute, Q&A.
  */
 
 import {
   getUnitProgress, saveUnitProgress, getLearnerProfileSummary,
   saveWorkProduct, saveScreenshot, getScreenshot,
-  getDiagnosticState, saveDiagnosticState, clearDiagnosticState,
+  getSummative, saveSummative, getSummativeAttempts, saveSummativeAttempt,
+  getGapAnalysis, saveGapAnalysis,
+  getJourney, saveJourney, updateJourneyPhase,
+  saveRubricReviewState, clearRubricReviewState,
 } from '../../js/storage.js';
 import * as orchestrator from '../../js/orchestrator.js';
 import { syncInBackground } from './syncDebounce.js';
 import {
   updateProfileInBackground, updateProfileFromFeedbackInBackground,
-  updateProfileOnUnitCompletionInBackground, ensureProfileExists,
+  updateProfileOnSummativeAttemptInBackground,
+  ensureProfileExists,
 } from './profileQueue.js';
 
-/** Build course scope context for agent calls. */
-export function buildCourseScope(unitId, courseGroups, units, allProgress) {
-  const group = courseGroups.find(cg => cg.units?.some(u => u.unitId === unitId));
-  if (!group) return null;
-  const groupUnits = group.units || [];
-  return {
-    courseName: group.name,
-    isRequired: !groupUnits.find(u => u.unitId === unitId)?.optional,
-    siblingUnits: groupUnits.map(u => ({
-      name: u.name, unitId: u.unitId, description: u.description,
-      completed: allProgress[u.unitId]?.status === 'completed',
-    })),
-  };
+// -- Course-level functions ---------------------------------------------------
+
+/** Collect all learning objectives across all units in a course group. */
+function collectObjectives(courseGroup) {
+  return (courseGroup.units || []).flatMap(u => u.learningObjectives || []);
 }
 
-/** Start the diagnostic conversation for a unit. Returns the initial result. */
-export async function startDiagnostic(unit, courseGroups, units, allProgress) {
+/** Initialize a course: generate the summative assessment. */
+export async function initCourse(courseGroup) {
+  await ensureProfileExists();
   const profileSummary = await getLearnerProfileSummary();
-  const courseScope = buildCourseScope(unit.unitId, courseGroups, units, allProgress);
+  const allObjectives = collectObjectives(courseGroup);
 
-  const context = JSON.stringify({
-    unitName: unit.name,
-    unitDescription: unit.description,
-    learningObjectives: unit.learningObjectives,
-    learnerProfile: profileSummary,
-    courseScope,
-  });
+  const summativeResult = await orchestrator.generateSummative(
+    courseGroup, allObjectives, profileSummary
+  );
 
-  const result = await orchestrator.converse('diagnostic-conversation', [
-    { role: 'user', content: context },
-  ], 1024);
-
-  const activity = {
-    id: `diagnostic-${unit.unitId}`,
-    type: 'final',
-    goal: unit.learningObjectives?.[unit.learningObjectives.length - 1] || '',
-    instruction: result.message,
-    tips: [],
+  const summativeData = {
+    task: summativeResult.task,
+    rubric: summativeResult.rubric,
+    exemplar: summativeResult.exemplar,
+    tool: summativeResult.task?.tool || null,
+    createdAt: Date.now(),
   };
+  await saveSummative(courseGroup.courseId, summativeData);
+  await saveJourney(courseGroup.courseId, { plan: {}, phase: 'rubric_review' });
+  syncInBackground(`summative:${courseGroup.courseId}`);
 
-  return { result, activity };
+  return summativeData;
 }
 
-/** Send a message in the diagnostic conversation. */
-export async function sendDiagnosticMessage(text, unit, diagnosticActivity, messages, courseGroups, units, allProgress) {
+/** Send a message in the rubric review conversation. */
+export async function sendRubricReviewMessage(courseId, text, summative, messages, courseGroup) {
   const profileSummary = await getLearnerProfileSummary();
-  const courseScope = buildCourseScope(unit.unitId, courseGroups, units, allProgress);
+  const allObjectives = collectObjectives(courseGroup);
 
   const context = JSON.stringify({
-    unitName: unit.name,
-    unitDescription: unit.description,
-    learningObjectives: unit.learningObjectives,
+    summative: { task: summative.task, rubric: summative.rubric, exemplar: summative.exemplar },
+    courseName: courseGroup.name,
+    learningObjectives: allObjectives,
     learnerProfile: profileSummary,
-    courseScope,
   });
 
   const fullMessages = [
@@ -78,53 +69,256 @@ export async function sendDiagnosticMessage(text, unit, diagnosticActivity, mess
   ];
 
   const result = await orchestrator.converse('diagnostic-conversation', fullMessages, 1024);
-  return result;
+
+  // Persist conversation state
+  const updatedMessages = [...messages,
+    { role: 'user', content: text, timestamp: Date.now() },
+    { role: 'assistant', content: result.message, timestamp: Date.now() + 1 },
+  ];
+  await saveRubricReviewState(courseId, { messages: updatedMessages });
+
+  // If the learner requested regeneration, regenerate the summative
+  if (result.regenerate && result.regenerationNotes) {
+    const newSummative = await orchestrator.generateSummative(
+      courseGroup, collectObjectives(courseGroup),
+      profileSummary, result.regenerationNotes
+    );
+    const summativeData = {
+      task: newSummative.task,
+      rubric: newSummative.rubric,
+      exemplar: newSummative.exemplar,
+      tool: newSummative.task?.tool || null,
+      personalized: true,
+      createdAt: Date.now(),
+    };
+    await saveSummative(courseId, summativeData);
+    syncInBackground(`summative:${courseId}`);
+    return { result, summative: summativeData, messages: updatedMessages };
+  }
+
+  return { result, summative: null, messages: updatedMessages };
 }
 
-/** Generate a learning plan and first activity for a unit. */
-export async function generatePlanAndFirstActivity(unit, diagnosticResult, courseGroups, units, allProgress, preferences) {
-  const profileSummary = await getLearnerProfileSummary();
-  const completedUnitNames = Object.entries(allProgress)
-    .filter(([, p]) => p.status === 'completed')
-    .map(([id]) => units.find(c => c.unitId === id)?.name)
-    .filter(Boolean);
-  const courseScope = buildCourseScope(unit.unitId, courseGroups, units, allProgress);
+/** Confirm rubric review is done, transition to baseline attempt. */
+export async function confirmRubric(courseId) {
+  await updateJourneyPhase(courseId, 'baseline_attempt');
+  await clearRubricReviewState(courseId);
+  syncInBackground(`journey:${courseId}`);
+}
 
-  const plan = await orchestrator.createLearningPlan(
-    unit, preferences, profileSummary, completedUnitNames, diagnosticResult, courseScope
+/** Capture a screenshot for one step of the multi-step summative. */
+export async function recordSummativeCapture(courseId, stepIndex) {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const pageUrl = tab?.url || '';
+
+  if (!pageUrl || pageUrl.startsWith('chrome://') || pageUrl.startsWith('about:') || pageUrl.startsWith('edge://')) {
+    throw new Error('Navigate to a webpage before capturing.');
+  }
+
+  const hasPermission = await chrome.permissions.contains({ origins: ['<all_urls>'] });
+  if (!hasPermission) {
+    const granted = await chrome.permissions.request({ origins: ['<all_urls>'] });
+    if (!granted) throw new Error('Permission needed to capture screenshots.');
+  }
+
+  const response = await chrome.runtime.sendMessage({ type: 'captureScreenshot' });
+  if (!response?.dataUrl) throw new Error('Screenshot capture failed.');
+
+  const screenshotKey = `summative-${courseId}-step${stepIndex}-${Date.now()}`;
+  await saveScreenshot(screenshotKey, response.dataUrl);
+
+  return { screenshotKey, dataUrl: response.dataUrl, stepIndex, url: pageUrl };
+}
+
+/** Submit a summative attempt (all steps captured). */
+export async function submitSummativeAttempt(courseId, courseGroup, captures) {
+  const summative = await getSummative(courseId);
+  const priorAttempts = await getSummativeAttempts(courseId);
+  const profileSummary = await getLearnerProfileSummary();
+
+  const screenshots = captures.map(c => ({ dataUrl: c.dataUrl, stepIndex: c.stepIndex }));
+
+  const result = await orchestrator.assessSummativeAttempt(
+    courseGroup, summative, screenshots, priorAttempts, profileSummary
   );
 
-  const firstSlot = plan.activities[0];
+  const attempt = {
+    id: `attempt-${courseId}-${Date.now()}`,
+    attemptNumber: priorAttempts.length + 1,
+    screenshots: captures.map(c => ({ screenshot_key: c.screenshotKey, step_index: c.stepIndex, url: c.url })),
+    criteriaScores: result.criteriaScores,
+    overallScore: result.overallScore,
+    mastery: result.mastery,
+    feedback: result.feedback,
+    nextSteps: result.nextSteps || [],
+    isBaseline: priorAttempts.length === 0,
+    timestamp: Date.now(),
+  };
+
+  await saveSummativeAttempt(courseId, attempt);
+  syncInBackground(`summative-attempts:${courseId}`);
+
+  // Update profile in background
+  updateProfileOnSummativeAttemptInBackground(courseGroup, attempt);
+
+  return { attempt, mastery: result.mastery };
+}
+
+/** Run gap analysis and generate the learning journey. */
+export async function generateGapAndJourney(courseId, courseGroup) {
+  const summative = await getSummative(courseId);
+  const attempts = await getSummativeAttempts(courseId);
+  const latestAttempt = attempts[attempts.length - 1];
+  const profileSummary = await getLearnerProfileSummary();
+
+  // Gap analysis
+  await updateJourneyPhase(courseId, 'gap_analysis');
+  const gapResult = await orchestrator.analyzeGaps(
+    courseGroup, summative.rubric, latestAttempt, profileSummary
+  );
+  await saveGapAnalysis(courseId, {
+    gaps: gapResult.gaps,
+    suggestedFocus: gapResult.suggestedFocus || [],
+  });
+  syncInBackground(`gap:${courseId}`);
+
+  // Journey generation
+  await updateJourneyPhase(courseId, 'journey_generation');
+  const journeyResult = await orchestrator.generateJourney(
+    courseGroup, courseGroup.units, gapResult, summative.rubric, profileSummary
+  );
+
+  await saveJourney(courseId, {
+    plan: journeyResult,
+    phase: 'formative_learning',
+  });
+  syncInBackground(`journey:${courseId}`);
+
+  // Initialize unit records for each journey unit
+  for (let i = 0; i < journeyResult.units.length; i++) {
+    const ju = journeyResult.units[i];
+    await saveUnitProgress(ju.unitId, {
+      status: 'not_started',
+      currentActivityIndex: 0,
+      journeyOrder: i,
+      rubricCriteria: ju.activities.flatMap(a => a.rubricCriteria || []).filter((v, idx, arr) => arr.indexOf(v) === idx),
+      activities: [],
+      drafts: [],
+    });
+  }
+
+  return { gapAnalysis: gapResult, journey: journeyResult };
+}
+
+/** Request a summative retake after formative learning. */
+export async function requestSummativeRetake(courseId) {
+  await updateJourneyPhase(courseId, 'summative_retake');
+  syncInBackground(`journey:${courseId}`);
+}
+
+/** Generate remediation formative activities after a failed retake. */
+export async function generateRemediationActivities(courseId, courseGroup, weakCriteria) {
+  const summative = await getSummative(courseId);
+  const profileSummary = await getLearnerProfileSummary();
+  const existingJourney = await getJourney(courseId);
+
+  // Get completed formative summaries
+  const completedFormatives = [];
+  if (existingJourney?.plan?.units) {
+    for (const ju of existingJourney.plan.units) {
+      const progress = await getUnitProgress(ju.unitId);
+      if (progress) {
+        for (const a of progress.activities || []) {
+          const drafts = (progress.drafts || []).filter(d => d.activityId === a.id);
+          const best = drafts.reduce((max, d) => d.score > max ? d.score : max, 0);
+          completedFormatives.push({ type: a.type, goal: a.goal, bestScore: best });
+        }
+      }
+    }
+  }
+
+  // Re-analyze gaps with latest attempt
+  const attempts = await getSummativeAttempts(courseId);
+  const latestAttempt = attempts[attempts.length - 1];
+  const gapResult = await orchestrator.analyzeGaps(
+    courseGroup, summative.rubric, latestAttempt, profileSummary
+  );
+  await saveGapAnalysis(courseId, {
+    gaps: gapResult.gaps,
+    suggestedFocus: gapResult.suggestedFocus || [],
+  });
+
+  // Generate new journey segment targeting weak criteria
+  const journeyResult = await orchestrator.generateJourney(
+    courseGroup, courseGroup.units, gapResult, summative.rubric,
+    profileSummary, completedFormatives
+  );
+
+  await saveJourney(courseId, {
+    plan: journeyResult,
+    phase: 'formative_learning',
+  });
+  syncInBackground(`journey:${courseId}`);
+
+  return { gapAnalysis: gapResult, journey: journeyResult };
+}
+
+// -- Unit-level functions (formative activities) ------------------------------
+
+/** Generate the first formative activity for a unit from the journey plan. */
+export async function generateFirstActivity(unit, journeyPlan, courseGroup) {
+  const profileSummary = await getLearnerProfileSummary();
+  const journeyUnit = journeyPlan.units?.find(u => u.unitId === unit.unitId);
+  if (!journeyUnit?.activities?.length) throw new Error('No activities planned for this unit.');
+
+  const slot = journeyUnit.activities[0];
+  const planContext = {
+    workProductDescription: journeyPlan.workProductDescription,
+    workProductTool: journeyPlan.workProductTool,
+  };
+
   const generated = await orchestrator.generateNextActivity(
-    unit, firstSlot, [], profileSummary, plan, courseScope
+    unit, slot, [], profileSummary, planContext
   );
 
-  return { plan, firstActivity: { ...firstSlot, instruction: generated.instruction, tips: generated.tips, messages: [] } };
+  return {
+    ...slot,
+    instruction: generated.instruction,
+    tips: generated.tips,
+    messages: [],
+  };
 }
 
-/** Generate the next activity for a unit. */
-export async function generateNextActivity(unit, progress, courseGroups, units, allProgress) {
+/** Generate the next formative activity for a unit. */
+export async function generateNextActivity(unit, progress, journeyPlan) {
   const profileSummary = await getLearnerProfileSummary();
-  const courseScope = buildCourseScope(unit.unitId, courseGroups, units, allProgress);
-  const plan = progress.learningPlan;
-  const slot = plan.activities[progress.currentActivityIndex];
+  const journeyUnit = journeyPlan.units?.find(u => u.unitId === unit.unitId);
+  if (!journeyUnit) throw new Error('Unit not found in journey plan.');
+
+  const slot = journeyUnit.activities[progress.currentActivityIndex];
+  if (!slot) throw new Error('No more activities planned for this unit.');
+
+  const planContext = {
+    workProductDescription: journeyPlan.workProductDescription,
+    workProductTool: journeyPlan.workProductTool,
+  };
 
   const progressSummary = progress.activities
     .slice(0, progress.currentActivityIndex)
-    .map((a, i) => {
+    .map(a => {
       const drafts = progress.drafts.filter(d => d.activityId === a.id);
       const best = drafts.reduce((max, d) => d.score > max ? d.score : max, 0);
       return `${a.type}: ${a.goal} (best score: ${Math.round(best * 100)}%)`;
     }).join('\n');
 
   const generated = await orchestrator.generateNextActivity(
-    unit, slot, progressSummary, profileSummary, plan, courseScope
+    unit, slot, progressSummary, profileSummary, planContext
   );
 
   return { ...slot, instruction: generated.instruction, tips: generated.tips, messages: [] };
 }
 
-/** Record a draft (capture screenshot + assess). */
+/** Record a formative draft (capture screenshot + assess). */
 export async function recordDraft(unit, progress, activity) {
   // Get active tab
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
@@ -134,14 +328,12 @@ export async function recordDraft(unit, progress, activity) {
     throw new Error('Navigate to a webpage before recording.');
   }
 
-  // Request permission if needed
   const hasPermission = await chrome.permissions.contains({ origins: ['<all_urls>'] });
   if (!hasPermission) {
     const granted = await chrome.permissions.request({ origins: ['<all_urls>'] });
     if (!granted) throw new Error('Permission needed to capture screenshots.');
   }
 
-  // Capture screenshot
   const response = await chrome.runtime.sendMessage({ type: 'captureScreenshot' });
   if (!response?.dataUrl) throw new Error('Screenshot capture failed.');
   const dataUrl = response.dataUrl;
@@ -164,6 +356,7 @@ export async function recordDraft(unit, progress, activity) {
     improvements: result.improvements,
     score: result.score,
     recommendation: result.recommendation,
+    rubricCriteriaScores: result.rubricCriteriaScores || null,
     timestamp: Date.now(),
   };
 
@@ -171,20 +364,11 @@ export async function recordDraft(unit, progress, activity) {
   const newProgress = { ...progress };
   newProgress.drafts = [...newProgress.drafts, draft];
 
-  const justCompleted = activity.type === 'final' && result.passed;
-  if (justCompleted) {
-    newProgress.status = 'completed';
-    newProgress.completedAt = Date.now();
-    newProgress.finalWorkProductUrl = pageUrl;
-    await saveWorkProduct({ unitId: unit.unitId, courseName: unit.name, url: pageUrl, completedAt: newProgress.completedAt });
-  }
-
   await saveUnitProgress(unit.unitId, newProgress);
   syncInBackground(`progress:${unit.unitId}`);
-  if (justCompleted) { syncInBackground('work'); updateProfileOnUnitCompletionInBackground(unit, newProgress); }
   updateProfileInBackground(result, unit, activity);
 
-  return { newProgress, draft, justCompleted };
+  return { newProgress, draft };
 }
 
 /** Submit a dispute on a draft assessment. */
@@ -203,7 +387,6 @@ export async function submitDispute(unit, progress, activity, draft, feedbackTex
     priorDrafts, profileSummary, previousAssessment, feedbackText
   );
 
-  // Update draft in place
   const newDrafts = progress.drafts.map(d => d.id === draft.id ? {
     ...d, feedback: result.feedback, strengths: result.strengths,
     improvements: result.improvements, score: result.score,
@@ -212,20 +395,11 @@ export async function submitDispute(unit, progress, activity, draft, feedbackTex
 
   const newProgress = { ...progress, drafts: newDrafts };
 
-  const justCompleted = activity.type === 'final' && result.passed && progress.status !== 'completed';
-  if (justCompleted) {
-    newProgress.status = 'completed';
-    newProgress.completedAt = Date.now();
-    newProgress.finalWorkProductUrl = draft.url;
-    await saveWorkProduct({ unitId: unit.unitId, courseName: unit.name, url: draft.url, completedAt: newProgress.completedAt });
-  }
-
   await saveUnitProgress(unit.unitId, newProgress);
   syncInBackground(`progress:${unit.unitId}`);
-  if (justCompleted) { syncInBackground('work'); updateProfileOnUnitCompletionInBackground(unit, newProgress); }
   updateProfileFromFeedbackInBackground(feedbackText, unit, activity);
 
-  return { newProgress, justCompleted };
+  return { newProgress };
 }
 
 /** Ask a Q&A question about an activity. */
@@ -242,7 +416,7 @@ Learner profile: ${profileSummary}
 Respond in plain text (not JSON). Be brief and direct.`;
 
   const history = (activity.messages || []).map(m => ({ role: m.role, content: m.content }));
-  history.push({ role: 'user', content: `Learner name: ${progress.unitId}\n\nLearner question: ${text}` });
+  history.push({ role: 'user', content: `Learner question: ${text}` });
 
   const response = await orchestrator.chatWithContext(systemPrompt, history);
 
@@ -253,7 +427,6 @@ Respond in plain text (not JSON). Be brief and direct.`;
     { role: 'assistant', content: response, timestamp: now + 1 },
   ];
 
-  // Update progress with new messages
   const newActivities = progress.activities.map(a =>
     a.id === activity.id ? { ...a, messages: newMessages } : a
   );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,26 +15,31 @@ async function bootstrap() {
   initialized = true;
 
   // Seed from .env.js if present (dev convenience — file is gitignored).
-  // Fetched at runtime (not bundled) since .env.js is copied to dist/ by viteStaticCopy.
+  // Loaded at runtime via chrome.runtime.getURL since Vite can't bundle dotfiles.
   try {
-    const envResp = await fetch('.env.js');
+    const envUrl = chrome.runtime.getURL('.env.js');
+    const envResp = await fetch(envUrl);
     if (!envResp.ok) throw new Error('no .env.js');
     const envText = await envResp.text();
-    const envBlob = new Blob([envText], { type: 'application/javascript' });
-    const envUrl = URL.createObjectURL(envBlob);
-    const { ENV } = await import(/* @vite-ignore */ envUrl);
-    URL.revokeObjectURL(envUrl);
+    // Parse the exported ENV object from the JS module text
+    const match = envText.match(/export\s+const\s+ENV\s*=\s*(\{[\s\S]*?\});/);
+    if (!match) throw new Error('no ENV export');
+    const ENV = JSON.parse(match[1]
+      .replace(/'/g, '"')
+      .replace(/,\s*([\]}])/g, '$1')
+      .replace(/(\w+)\s*:/g, '"$1":')
+    );
     const { getApiKey, saveApiKey, getPreferences, savePreferences } = await import('../js/storage.js');
-    if (ENV.apiKey && !(await getApiKey())) await saveApiKey(ENV.apiKey);
+    if (ENV.apiKey) await saveApiKey(ENV.apiKey);
     if (ENV.name) {
       const prefs = await getPreferences();
-      if (!prefs.name) await savePreferences({ ...prefs, name: ENV.name });
+      await savePreferences({ ...prefs, name: ENV.name });
     }
     // Store credentials for form pre-fill (not auto-login)
     if (ENV.email || ENV.password) {
       globalThis.__envCredentials = { email: ENV.email || '', password: ENV.password || '' };
     }
-  } catch { /* .env.js not present — that's fine */ }
+  } catch (e) { console.warn('.env.js load failed:', e.message || e); }
 
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -14,12 +14,16 @@ async function bootstrap() {
   if (initialized) return;
   initialized = true;
 
-  // Seed from .env.js if present (dev convenience — file is gitignored)
+  // Seed from .env.js if present (dev convenience — file is gitignored).
+  // Fetched at runtime (not bundled) since .env.js is copied to dist/ by viteStaticCopy.
   try {
-    const envModules = import.meta.glob('../.env.js', { eager: true });
-    const envMod = envModules['../.env.js'];
-    if (!envMod) throw new Error('no .env.js');
-    const { ENV } = envMod;
+    const envResp = await fetch('.env.js');
+    if (!envResp.ok) throw new Error('no .env.js');
+    const envText = await envResp.text();
+    const envBlob = new Blob([envText], { type: 'application/javascript' });
+    const envUrl = URL.createObjectURL(envBlob);
+    const { ENV } = await import(/* @vite-ignore */ envUrl);
+    URL.revokeObjectURL(envUrl);
     const { getApiKey, saveApiKey, getPreferences, savePreferences } = await import('../js/storage.js');
     if (ENV.apiKey && !(await getApiKey())) await saveApiKey(ENV.apiKey);
     if (ENV.name) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -39,7 +39,7 @@ async function bootstrap() {
     if (ENV.email || ENV.password) {
       globalThis.__envCredentials = { email: ENV.email || '', password: ENV.password || '' };
     }
-  } catch (e) { console.warn('.env.js load failed:', e.message || e); }
+  } catch (e) { console.error('[1111] .env.js load failed:', e.message || e); }
 
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
@@ -58,6 +58,6 @@ async function bootstrap() {
 
 // Initialize database, then mount React
 initDatabase().then(bootstrap).catch((err) => {
-  console.error('Failed to initialize database:', err);
+  console.error('[1111] Failed to initialize database:', err);
   document.getElementById('root').textContent = 'Failed to load. Please reload the extension.';
 });

--- a/src/pages/CoursesList.jsx
+++ b/src/pages/CoursesList.jsx
@@ -1,67 +1,75 @@
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext.jsx';
+import { getCoursePhase } from '../../js/storage.js';
+import { COURSE_PHASES } from '../lib/constants.js';
+
+const PHASE_LABELS = {
+  [COURSE_PHASES.SUMMATIVE_SETUP]: 'Setting up...',
+  [COURSE_PHASES.RUBRIC_REVIEW]: 'Review rubric',
+  [COURSE_PHASES.BASELINE_ATTEMPT]: 'Baseline assessment',
+  [COURSE_PHASES.GAP_ANALYSIS]: 'Analyzing...',
+  [COURSE_PHASES.JOURNEY_GENERATION]: 'Building journey...',
+  [COURSE_PHASES.FORMATIVE_LEARNING]: 'In progress',
+  [COURSE_PHASES.SUMMATIVE_RETAKE]: 'Retaking assessment',
+  [COURSE_PHASES.COMPLETED]: 'Mastery achieved',
+};
 
 export default function CoursesList() {
   const { state } = useApp();
   const navigate = useNavigate();
-  const { courseGroups, units, allProgress } = state;
+  const { courseGroups } = state;
+  const [phases, setPhases] = useState({});
 
-  function courseGroupStatus(cg) {
-    const groupUnits = cg.units || [cg];
-    const statuses = groupUnits.map(u => allProgress[u.unitId]?.status || 'not_started');
-    if (statuses.every(s => s === 'completed')) return 'completed';
-    if (statuses.some(s => s === 'in_progress' || s === 'completed')) return 'in_progress';
-    return 'not_started';
-  }
+  // Load phases for all courses
+  useEffect(() => {
+    (async () => {
+      const p = {};
+      for (const cg of courseGroups) {
+        const phase = await getCoursePhase(cg.courseId);
+        if (phase) p[cg.courseId] = phase;
+      }
+      setPhases(p);
+    })();
+  }, [courseGroups]);
 
-  function statusIcon(status) {
-    if (status === 'completed') return '\u2713';
-    if (status === 'in_progress') return '\u25B6';
+  function statusIcon(courseId) {
+    const phase = phases[courseId];
+    if (phase === COURSE_PHASES.COMPLETED) return '\u2713';
+    if (phase) return '\u25B6';
     return '\u25CB';
   }
 
   function progressLabel(cg, locked) {
     if (locked) return 'Complete prerequisite first';
-    const groupUnits = cg.units || [cg];
-    const completed = groupUnits.filter(u => allProgress[u.unitId]?.status === 'completed').length;
-    const total = groupUnits.length;
-    const mins = groupUnits.reduce((sum, u) => sum + (u.learningObjectives?.length || 1) * 5 + 2, 0);
-    if (completed === total) return 'Completed';
-    return `${completed} of ${total} units \u00b7 ~${mins} min`;
+    const phase = phases[cg.courseId];
+    if (phase) return PHASE_LABELS[phase] || phase;
+    const totalObjectives = (cg.units || []).reduce((sum, u) => sum + (u.learningObjectives?.length || 0), 0);
+    const mins = totalObjectives * 5 + 10; // rough estimate
+    return `~${mins} min`;
   }
 
-  function checkCourseGroupPrerequisite(cg) {
+  function checkPrerequisite(cg) {
     if (!cg.dependsOn) return true;
     const dep = courseGroups.find(g => g.courseId === cg.dependsOn);
     if (!dep) return true;
-    const depUnits = dep.units || [dep];
-    return depUnits.every(u => allProgress[u.unitId]?.status === 'completed');
+    return phases[dep.courseId] === COURSE_PHASES.COMPLETED;
   }
-
-  const handleClick = (cg) => {
-    if (!checkCourseGroupPrerequisite(cg)) return;
-    if (cg.units) {
-      navigate(`/courses/${cg.courseId}`);
-    } else {
-      navigate(`/unit/${cg.unitId}`);
-    }
-  };
 
   return (
     <>
       <h2>Courses</h2>
       <div className="course-list" role="list">
         {courseGroups.map((cg, i) => {
-          const status = courseGroupStatus(cg);
-          const locked = !checkCourseGroupPrerequisite(cg);
-          const icon = statusIcon(status);
+          const locked = !checkPrerequisite(cg);
+          const icon = statusIcon(cg.courseId);
           return (
             <button
               key={cg.courseId}
               className={`course-card${locked ? ' locked' : ''} stagger-item`}
               style={{ animationDelay: `${i * 40}ms` }}
               role="listitem"
-              onClick={() => handleClick(cg)}
+              onClick={() => !locked && navigate(`/courses/${cg.courseId}`)}
               disabled={locked}
             >
               <span className="course-status" aria-hidden="true">{icon}</span>

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,40 +1,68 @@
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext.jsx';
-import { TYPE_LABELS } from '../lib/constants.js';
+import { getSummative, getSummativeAttempts, getJourney, getCoursePhase } from '../../js/storage.js';
+import { COURSE_PHASES } from '../lib/constants.js';
 
 export default function Portfolio() {
   const { state } = useApp();
   const navigate = useNavigate();
-  const { units, allProgress } = state;
+  const { courseGroups, allProgress } = state;
+  const [courseWork, setCourseWork] = useState([]);
 
-  const workedUnits = units.filter(u => allProgress[u.unitId]?.learningPlan);
+  useEffect(() => {
+    (async () => {
+      const work = [];
+      for (const cg of courseGroups) {
+        const phase = await getCoursePhase(cg.courseId);
+        if (!phase) continue; // no work started
+
+        const summative = await getSummative(cg.courseId);
+        const attempts = await getSummativeAttempts(cg.courseId);
+        const journey = await getJourney(cg.courseId);
+
+        // Count formative drafts across all units
+        let draftCount = 0;
+        for (const ju of journey?.plan?.units || []) {
+          const p = allProgress[ju.unitId];
+          draftCount += p?.drafts?.length || 0;
+        }
+
+        const isMastered = phase === COURSE_PHASES.COMPLETED;
+        const workProductName = journey?.plan?.workProductDescription || summative?.exemplar?.slice(0, 40) || cg.name;
+
+        work.push({
+          courseId: cg.courseId,
+          courseName: cg.name,
+          workProductName,
+          phase,
+          isMastered,
+          attemptCount: attempts.length,
+          draftCount: draftCount + attempts.length, // summative + formative captures
+        });
+      }
+      setCourseWork(work);
+    })();
+  }, [courseGroups, allProgress]);
 
   return (
     <>
       <h2>Work</h2>
-      {workedUnits.length === 0 ? (
-        <p className="empty-state">Complete activities to build your portfolio.</p>
+      {courseWork.length === 0 ? (
+        <p className="empty-state">Start a course to build your portfolio.</p>
       ) : (
         <ul className="work-list">
-          {workedUnits.map((u, i) => {
-            const p = allProgress[u.unitId];
-            const plan = p.learningPlan;
-            const workName = plan.finalWorkProductDescription || u.name;
-            const draftCount = p.drafts?.length || 0;
-            const isCompleted = p.status === 'completed';
-
-            return (
-              <li key={u.unitId} style={{ animationDelay: `${(i + 1) * 0.04}s` }}>
-                <button className="work-card" onClick={() => navigate(`/work/${u.unitId}`)}>
-                  <strong className="work-card-title">{workName}</strong>
-                  <div className="work-card-stats">
-                    <span>{isCompleted ? 'Completed' : 'In progress'}</span>
-                    <span>{draftCount} capture{draftCount !== 1 ? 's' : ''}</span>
-                  </div>
-                </button>
-              </li>
-            );
-          })}
+          {courseWork.map((cw, i) => (
+            <li key={cw.courseId} style={{ animationDelay: `${(i + 1) * 0.04}s` }}>
+              <button className="work-card" onClick={() => navigate(`/work/${cw.courseId}`)}>
+                <strong className="work-card-title">{cw.courseName}</strong>
+                <div className="work-card-stats">
+                  <span>{cw.isMastered ? 'Mastery achieved' : 'In progress'}</span>
+                  <span>{cw.draftCount} capture{cw.draftCount !== 1 ? 's' : ''}</span>
+                </div>
+              </button>
+            </li>
+          ))}
         </ul>
       )}
     </>

--- a/src/pages/PortfolioDetail.jsx
+++ b/src/pages/PortfolioDetail.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext.jsx';
-import { TYPE_LABELS, TYPE_LETTERS } from '../lib/constants.js';
+import { TYPE_LABELS, TYPE_LETTERS, scoreToLabel, levelToLabel } from '../lib/constants.js';
 import { getScreenshot, getSummative, getSummativeAttempts, getJourney } from '../../js/storage.js';
 
 export default function PortfolioDetail() {
@@ -57,14 +57,13 @@ export default function PortfolioDetail() {
                   {attempt.mastery && <span style={{ color: '#2d7d46', marginLeft: '8px', fontWeight: 600 }}>Mastery</span>}
                 </div>
                 <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', marginBottom: '4px' }}>
-                  {Math.round((attempt.overallScore || 0) * 100)}% overall
+                  {scoreToLabel(attempt.overallScore || 0)}
                 </div>
                 {/* Per-criterion scores */}
                 {attempt.criteriaScores?.map((cs, ci) => (
                   <div key={ci} style={{ fontSize: '0.75rem', display: 'flex', gap: '6px', marginBottom: '2px' }}>
                     <span style={{ fontWeight: 500, minWidth: '40%' }}>{cs.criterion}</span>
-                    <span style={{ textTransform: 'capitalize' }}>{cs.level}</span>
-                    <span style={{ color: 'var(--color-text-secondary)' }}>{Math.round(cs.score * 100)}%</span>
+                    <span>{levelToLabel(cs.level)}</span>
                   </div>
                 ))}
                 {/* Screenshot thumbnails */}
@@ -160,7 +159,7 @@ function TimelineDraft({ draft, unitId }) {
   const navigate = useNavigate();
   const [screenshot, setScreenshot] = useState(null);
   const [loading, setLoading] = useState(false);
-  const scorePercent = draft.score != null ? Math.round(draft.score * 100) + '%' : '';
+  const scoreLabel = draft.score != null ? scoreToLabel(draft.score) : '';
   const time = draft.timestamp ? new Date(draft.timestamp).toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
 
   const loadScreenshot = async () => {
@@ -178,7 +177,7 @@ function TimelineDraft({ draft, unitId }) {
 
   return (
     <div className="timeline-draft">
-      <span className="timeline-draft-score">{scorePercent}</span>
+      <span className="timeline-draft-score">{scoreLabel}</span>
       <span className="timeline-draft-time">{time}</span>
       <button className="timeline-draft-link" onClick={goToChat} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, font: 'inherit' }}>
         View in chat

--- a/src/pages/PortfolioDetail.jsx
+++ b/src/pages/PortfolioDetail.jsx
@@ -1,50 +1,158 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext.jsx';
 import { TYPE_LABELS, TYPE_LETTERS } from '../lib/constants.js';
-import { getScreenshot } from '../../js/storage.js';
+import { getScreenshot, getSummative, getSummativeAttempts, getJourney } from '../../js/storage.js';
 
 export default function PortfolioDetail() {
-  const { unitId } = useParams();
+  const { courseId } = useParams();
   const navigate = useNavigate();
   const { state } = useApp();
-  const unit = state.units.find(u => u.unitId === unitId);
-  const progress = state.allProgress[unitId];
+  const courseGroup = state.courseGroups.find(cg => cg.courseId === courseId);
 
-  if (!unit || !progress) return <p>Not found.</p>;
+  const [summative, setSummative] = useState(null);
+  const [attempts, setAttempts] = useState([]);
+  const [journey, setJourney] = useState(null);
 
-  const plan = progress.learningPlan;
+  useEffect(() => {
+    if (!courseId) return;
+    (async () => {
+      const s = await getSummative(courseId);
+      setSummative(s);
+      const a = await getSummativeAttempts(courseId);
+      setAttempts(a);
+      const j = await getJourney(courseId);
+      setJourney(j);
+    })();
+  }, [courseId]);
+
+  if (!courseGroup) return <p>Not found.</p>;
+
+  const journeyUnits = journey?.plan?.units || [];
 
   return (
     <>
       <div className="course-header" style={{ marginBottom: 'var(--space)' }}>
         <button className="back-btn" aria-label="Back to work" onClick={() => navigate('/work')}>&larr;</button>
         <div className="course-header-info">
-          <h2>{plan?.finalWorkProductDescription || unit.name}</h2>
+          <h2>{courseGroup.name}</h2>
         </div>
       </div>
-      <div className="build-timeline">
-        {(plan?.activities || []).map((slot, i) => {
-          const activity = progress.activities?.[i];
-          const drafts = progress.drafts?.filter(d => d.activityId === (activity?.id || slot.id)) || [];
-          const isCurrent = i === progress.currentActivityIndex && progress.status !== 'completed';
-          const isFuture = !activity;
 
-          return (
-            <div key={i} className={`timeline-step${isCurrent ? ' timeline-current' : ''}${isFuture ? ' timeline-future' : ''}`}>
-              <div className="timeline-step-header">
-                <span className="timeline-type-letter">{TYPE_LETTERS[slot.type] || '?'}</span>
-                <strong>{TYPE_LABELS[slot.type] || slot.type}</strong>
+      {/* Summative section */}
+      {summative && (
+        <div style={{ marginBottom: 'var(--space)' }}>
+          <h3 style={{ fontSize: '0.9rem', margin: '0 0 8px', padding: '0 var(--space, 12px)' }}>
+            Summative Assessment
+          </h3>
+          <p style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', margin: '0 0 8px', padding: '0 var(--space, 12px)' }}>
+            {summative.task?.description || 'Assessment task'}
+          </p>
+          <div className="build-timeline">
+            {attempts.map((attempt, ai) => (
+              <div key={attempt.id} className="timeline-step">
+                <div className="timeline-step-header">
+                  <span className="timeline-type-letter">{attempt.isBaseline ? 'B' : `R${attempt.attemptNumber - 1}`}</span>
+                  <strong>{attempt.isBaseline ? 'Baseline' : `Retake ${attempt.attemptNumber - 1}`}</strong>
+                  {attempt.mastery && <span style={{ color: '#2d7d46', marginLeft: '8px', fontWeight: 600 }}>Mastery</span>}
+                </div>
+                <div style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', marginBottom: '4px' }}>
+                  {Math.round((attempt.overallScore || 0) * 100)}% overall
+                </div>
+                {/* Per-criterion scores */}
+                {attempt.criteriaScores?.map((cs, ci) => (
+                  <div key={ci} style={{ fontSize: '0.75rem', display: 'flex', gap: '6px', marginBottom: '2px' }}>
+                    <span style={{ fontWeight: 500, minWidth: '40%' }}>{cs.criterion}</span>
+                    <span style={{ textTransform: 'capitalize' }}>{cs.level}</span>
+                    <span style={{ color: 'var(--color-text-secondary)' }}>{Math.round(cs.score * 100)}%</span>
+                  </div>
+                ))}
+                {/* Screenshot thumbnails */}
+                {attempt.screenshots?.map((ss, si) => (
+                  <SummativeScreenshot key={si} screenshotKey={ss.screenshot_key} stepIndex={ss.step_index} />
+                ))}
               </div>
-              <p style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', marginBottom: '4px' }}>{slot.goal}</p>
-              {drafts.map((d, di) => (
-                <TimelineDraft key={d.id} draft={d} unitId={unitId} />
-              ))}
-            </div>
-          );
-        })}
-      </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Formative section */}
+      {journeyUnits.length > 0 && (
+        <div>
+          <h3 style={{ fontSize: '0.9rem', margin: '0 0 8px', padding: '0 var(--space, 12px)' }}>
+            Learning Journey
+          </h3>
+          <div className="build-timeline">
+            {journeyUnits.map((ju, ui) => {
+              const unitDef = courseGroup.units?.find(u => u.unitId === ju.unitId);
+              const progress = state.allProgress[ju.unitId];
+              if (!progress?.activities?.length) return null;
+
+              return (
+                <div key={ju.unitId}>
+                  <div style={{ fontSize: '0.8rem', fontWeight: 600, margin: '8px 0 4px', padding: '0 var(--space, 12px)' }}>
+                    {unitDef?.name || ju.unitId}
+                  </div>
+                  {progress.activities.map((activity, ai) => {
+                    const drafts = (progress.drafts || []).filter(d => d.activityId === activity.id);
+                    return (
+                      <div key={ai} className="timeline-step">
+                        <div className="timeline-step-header">
+                          <span className="timeline-type-letter">{TYPE_LETTERS[activity.type] || '?'}</span>
+                          <strong>{TYPE_LABELS[activity.type] || activity.type}</strong>
+                        </div>
+                        <p style={{ fontSize: '0.8rem', color: 'var(--color-text-secondary)', marginBottom: '4px' }}>
+                          {activity.goal}
+                        </p>
+                        {activity.rubricCriteria?.length > 0 && (
+                          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '3px', marginBottom: '4px' }}>
+                            {activity.rubricCriteria.map((c, ci) => (
+                              <span key={ci} style={{
+                                fontSize: '0.65rem', padding: '1px 5px', borderRadius: '6px',
+                                background: 'var(--color-primary-light, #e8f0fe)', color: 'var(--color-primary, #1a73e8)',
+                              }}>{c}</span>
+                            ))}
+                          </div>
+                        )}
+                        {drafts.map(d => (
+                          <TimelineDraft key={d.id} draft={d} unitId={ju.unitId} />
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </>
+  );
+}
+
+function SummativeScreenshot({ screenshotKey, stepIndex }) {
+  const [screenshot, setScreenshot] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const loadScreenshot = async () => {
+    if (screenshot) { setScreenshot(null); return; }
+    if (!screenshotKey) return;
+    setLoading(true);
+    const data = await getScreenshot(screenshotKey);
+    setScreenshot(data);
+    setLoading(false);
+  };
+
+  return (
+    <div style={{ marginTop: '4px' }}>
+      <button className="timeline-screenshot-btn" onClick={loadScreenshot}>
+        {loading ? '...' : screenshot ? 'Hide' : `Step ${stepIndex + 1} screenshot`}
+      </button>
+      {screenshot && (
+        <img src={screenshot} alt={`Step ${stepIndex + 1} screenshot`} style={{ width: '100%', borderRadius: 'var(--radius)', marginTop: '4px' }} />
+      )}
+    </div>
   );
 }
 

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -137,7 +137,7 @@ function ProfileFeedbackModal({ onDone }) {
       hide();
       if (onDone) onDone();
     } catch (e) {
-      console.warn('Profile feedback failed:', e);
+      console.error('[1111] Profile feedback failed:', e?.message || e);
       setSubmitting(false);
     }
   };

--- a/src/pages/UnitChat.jsx
+++ b/src/pages/UnitChat.jsx
@@ -4,15 +4,11 @@ import { useApp } from '../contexts/AppContext.jsx';
 import { useModal } from '../contexts/ModalContext.jsx';
 import { TYPE_LABELS } from '../lib/constants.js';
 import { renderMd, esc, formatDuration } from '../lib/helpers.js';
-import {
-  getUnitProgress, saveUnitProgress,
-  clearDiagnosticState, saveDiagnosticState,
-} from '../../js/storage.js';
+import { getUnitProgress, saveUnitProgress, getJourney } from '../../js/storage.js';
 import { syncInBackground } from '../lib/syncDebounce.js';
-import { updateProfileFromFeedbackInBackground, updateProfileInBackground } from '../lib/profileQueue.js';
 import {
-  startDiagnostic, sendDiagnosticMessage, generatePlanAndFirstActivity,
-  generateNextActivity, recordDraft, submitDispute, askAboutActivity,
+  generateFirstActivity, generateNextActivity,
+  recordDraft, submitDispute, askAboutActivity,
 } from '../lib/unitEngine.js';
 
 import ChatArea from '../components/chat/ChatArea.jsx';
@@ -23,7 +19,6 @@ import InstructionMessage from '../components/chat/InstructionMessage.jsx';
 import DraftMessage from '../components/chat/DraftMessage.jsx';
 import FeedbackCard from '../components/chat/FeedbackCard.jsx';
 import ComposeBar from '../components/chat/ComposeBar.jsx';
-import CompletionSummary from '../components/chat/CompletionSummary.jsx';
 import DisputeModal from '../components/modals/DisputeModal.jsx';
 import ConfirmModal from '../components/modals/ConfirmModal.jsx';
 
@@ -37,15 +32,15 @@ export default function UnitChat() {
   const courseGroup = state.courseGroups.find(cg => cg.units?.some(u => u.unitId === unitId));
 
   const [progress, setProgress] = useState(null);
-  const [diagnostic, setDiagnostic] = useState({ phase: null, activity: null, messages: [], result: null });
+  const [journeyPlan, setJourneyPlan] = useState(null);
   const [loading, setLoading] = useState('');
   const [error, setError] = useState('');
 
-  // Load progress on mount or unit change
+  // Load progress and journey on mount
   useEffect(() => {
     let cancelled = false;
-    setDiagnostic({ phase: null, activity: null, messages: [], result: null });
     setProgress(null);
+    setJourneyPlan(null);
     setLoading('');
     setError('');
 
@@ -55,6 +50,38 @@ export default function UnitChat() {
 
       if (p) {
         setProgress(p);
+
+        // Load journey plan for this course
+        if (courseGroup) {
+          const j = await getJourney(courseGroup.courseId);
+          if (j?.plan) setJourneyPlan(j.plan);
+        }
+
+        // Generate first activity if none exist
+        if (!p.activities?.length && courseGroup) {
+          setLoading('generating');
+          try {
+            const j = await getJourney(courseGroup.courseId);
+            if (j?.plan) {
+              setJourneyPlan(j.plan);
+              const firstActivity = await generateFirstActivity(unit, j.plan, courseGroup);
+              const newProgress = {
+                ...p,
+                status: 'in_progress',
+                activities: [firstActivity],
+                startedAt: p.startedAt || Date.now(),
+              };
+              await saveUnitProgress(unitId, newProgress);
+              dispatch({ type: 'SET_PROGRESS', unitId, progress: newProgress });
+              syncInBackground(`progress:${unitId}`);
+              if (!cancelled) setProgress(newProgress);
+            }
+          } catch (e) {
+            if (!cancelled) setError(e.message || 'Failed to generate activity.');
+          }
+          if (!cancelled) setLoading('');
+        }
+
         // Scroll to specific draft if navigated from portfolio
         const scrollTo = searchParams.get('scrollTo');
         if (scrollTo) {
@@ -63,103 +90,13 @@ export default function UnitChat() {
           }, 100);
         }
       } else {
-        // Start diagnostic
-        setLoading('diagnostic');
-        try {
-          const { result, activity } = await startDiagnostic(unit, state.courseGroups, state.units, state.allProgress);
-          if (cancelled) return;
-
-          setDiagnostic({ phase: 'activity', activity, messages: [], result: null });
-
-          if (result.done) {
-            // Agent assessed from profile alone
-            const diagResult = {
-              score: result.score || 0.7,
-              feedback: result.feedback || result.message,
-              strengths: result.strengths || [],
-              improvements: result.improvements || [],
-              recommendation: 'advance', passed: true,
-            };
-            setDiagnostic(prev => ({ ...prev, result: { unitId, result: diagResult } }));
-            updateProfileInBackground(diagResult, unit, activity);
-          }
-        } catch (e) {
-          if (!cancelled) setError(e.message || 'Failed to start diagnostic.');
-        }
-        if (!cancelled) setLoading('');
+        // No progress — shouldn't happen in normal flow (UnitsList creates the record)
+        setError('No progress found for this unit. Return to the course page to start.');
       }
     })();
 
     return () => { cancelled = true; };
   }, [unitId]);
-
-  // Generate plan after diagnostic completes
-  const handleStartCourse = useCallback(async () => {
-    setLoading('plan');
-    try {
-      const diagResult = diagnostic.result?.result || null;
-      const { plan, firstActivity } = await generatePlanAndFirstActivity(
-        unit, diagResult, state.courseGroups, state.units, state.allProgress, state.preferences
-      );
-      const newProgress = {
-        unitId, status: 'in_progress', currentActivityIndex: 0,
-        diagnostic: diagnostic.activity ? {
-          instruction: diagnostic.activity.instruction,
-          messages: diagnostic.messages,
-          result: diagResult,
-        } : null,
-        learningPlan: { activities: plan.activities, finalWorkProductDescription: plan.finalWorkProductDescription, workProductTool: plan.workProductTool },
-        activities: [firstActivity], drafts: [],
-        startedAt: Date.now(), completedAt: null, finalWorkProductUrl: null,
-      };
-      await saveUnitProgress(unitId, newProgress);
-      dispatch({ type: 'SET_PROGRESS', unitId, progress: newProgress });
-      syncInBackground(`progress:${unitId}`);
-      clearDiagnosticState();
-      setProgress(newProgress);
-      setDiagnostic({ phase: null, activity: null, messages: [], result: null });
-    } catch (e) {
-      setError(e.message || 'Failed to generate course.');
-    }
-    setLoading('');
-  }, [unitId, unit, diagnostic, state, dispatch]);
-
-  // Diagnostic message send
-  const handleDiagnosticSend = useCallback(async (text) => {
-    const newMsgs = [...diagnostic.messages, { role: 'user', content: text }];
-    setDiagnostic(prev => ({ ...prev, messages: newMsgs }));
-    setLoading('diagnostic-reply');
-
-    try {
-      const result = await sendDiagnosticMessage(text, unit, diagnostic.activity, diagnostic.messages, state.courseGroups, state.units, state.allProgress);
-      const updatedMsgs = [...newMsgs, { role: 'assistant', content: JSON.stringify(result) }];
-      setDiagnostic(prev => ({ ...prev, messages: updatedMsgs }));
-
-      if (result.done) {
-        const diagResult = {
-          score: result.score || 0, feedback: result.feedback || result.message,
-          strengths: result.strengths || [], improvements: result.improvements || [],
-          recommendation: 'advance', passed: true,
-        };
-        setDiagnostic(prev => ({ ...prev, result: { unitId, result: diagResult } }));
-        updateProfileInBackground(diagResult, unit, diagnostic.activity);
-        // Don't auto-advance — let the user read the final message and click Continue
-      }
-    } catch (e) {
-      setDiagnostic(prev => ({
-        ...prev,
-        messages: [...newMsgs, { role: 'assistant', content: JSON.stringify({ message: 'Something went wrong. Try again or skip.' }) }],
-      }));
-    }
-    setLoading('');
-  }, [diagnostic, unit, state, unitId, handleStartCourse]);
-
-  // Skip diagnostic
-  const handleSkipDiagnostic = useCallback(() => {
-    const userText = diagnostic.messages.filter(m => m.role === 'user').map(m => m.content).join(' ');
-    if (userText) updateProfileFromFeedbackInBackground(userText, unit, diagnostic.activity || { type: 'diagnostic', goal: 'Skills check' });
-    handleStartCourse();
-  }, [diagnostic, unit, handleStartCourse]);
 
   // Activity Q&A
   const handleActivitySend = useCallback(async (text) => {
@@ -167,7 +104,6 @@ export default function UnitChat() {
     const activity = progress.activities[progress.currentActivityIndex];
     if (!activity) return;
 
-    // Show user message immediately
     const userMsg = { role: 'user', content: text, timestamp: Date.now() };
     const updatedActivities = progress.activities.map(a =>
       a.id === activity.id ? { ...a, messages: [...(a.messages || []), userMsg] } : a
@@ -202,15 +138,14 @@ export default function UnitChat() {
 
   // Advance to next activity
   const handleNextActivity = useCallback(async () => {
-    if (!progress) return;
+    if (!progress || !journeyPlan) return;
     const nextIndex = progress.currentActivityIndex + 1;
     let newProgress = { ...progress, currentActivityIndex: nextIndex };
 
-    // Generate next activity if not yet generated
     if (!newProgress.activities[nextIndex]) {
       setLoading('generating');
       try {
-        const nextActivity = await generateNextActivity(unit, newProgress, state.courseGroups, state.units, state.allProgress);
+        const nextActivity = await generateNextActivity(unit, newProgress, journeyPlan);
         newProgress = { ...newProgress, activities: [...newProgress.activities, nextActivity] };
       } catch (e) {
         setError(e.message || 'Failed to generate next activity.');
@@ -224,7 +159,7 @@ export default function UnitChat() {
     dispatch({ type: 'SET_PROGRESS', unitId, progress: newProgress });
     syncInBackground(`progress:${unitId}`);
     setProgress(newProgress);
-  }, [progress, unit, unitId, state, dispatch]);
+  }, [progress, journeyPlan, unit, unitId, dispatch]);
 
   // Dispute
   const handleDispute = useCallback((draft) => {
@@ -265,22 +200,24 @@ export default function UnitChat() {
 
   // --- Render ---
   const activity = progress?.activities?.[progress.currentActivityIndex];
-  const planActivities = progress?.learningPlan?.activities;
-  const isCompleted = progress?.status === 'completed';
-  const diagMsgCount = diagnostic.messages.filter(m => m.role === 'user').length;
-  const showSkip = diagMsgCount >= 2 && !diagnostic.result;
-  const showContinue = !!diagnostic.result && !progress;
+  const journeyUnit = journeyPlan?.units?.find(u => u.unitId === unitId);
+  const totalActivities = journeyUnit?.activities?.length || progress?.activities?.length || 0;
+  const isUnitDone = progress?.currentActivityIndex >= totalActivities && totalActivities > 0
+    && progress?.drafts?.some(d => {
+      const lastAct = progress.activities[progress.activities.length - 1];
+      return lastAct && d.activityId === lastAct.id && d.recommendation === 'advance';
+    });
   const activityDrafts = activity ? (progress?.drafts?.filter(d => d.activityId === activity.id) || []) : [];
   const latestDraft = activityDrafts[activityDrafts.length - 1];
   const isPassed = latestDraft?.recommendation === 'advance';
-  const remaining = planActivities ? planActivities.length - progress.currentActivityIndex - 1 : 0;
+  const remaining = totalActivities - (progress?.currentActivityIndex || 0) - 1;
 
   return (
     <div className="course-layout">
       <div className="course-header">
         <button
           className="back-btn"
-          aria-label={courseGroup ? 'Back to units' : 'Back to courses'}
+          aria-label={courseGroup ? 'Back to course' : 'Back to courses'}
           onClick={() => navigate(courseGroup ? `/courses/${courseGroup.courseId}` : '/courses')}
         >&larr;</button>
         <div className="course-header-info">
@@ -291,43 +228,7 @@ export default function UnitChat() {
       </div>
 
       <ChatArea>
-        {/* Skills Check */}
-        {(diagnostic.activity || progress?.diagnostic) && (
-          <div className="chat-section-heading" role="separator">Skills Check</div>
-        )}
-        {diagnostic.activity && (
-          <>
-            <AssistantMessage content={diagnostic.activity.instruction} />
-            {diagnostic.messages.map((m, i) => (
-              m.role === 'user'
-                ? <UserMessage key={i} content={m.content} />
-                : <AssistantMessage key={i} content={m.content} />
-            ))}
-          </>
-        )}
-        {!diagnostic.activity && progress?.diagnostic && (
-          <>
-            <AssistantMessage content={progress.diagnostic.instruction || ''} />
-            {progress.diagnostic.messages?.map((m, i) => (
-              m.role === 'user'
-                ? <UserMessage key={i} content={m.content} />
-                : <AssistantMessage key={i} content={m.content} />
-            ))}
-          </>
-        )}
-
-        {loading === 'diagnostic' && <ThinkingSpinner text="Preparing your skills check..." />}
-        {loading === 'diagnostic-reply' && <ThinkingSpinner />}
-        {loading === 'plan' && <ThinkingSpinner text="Building your learning plan..." />}
-
-        {showSkip && (
-          <button className="skip-step-btn" onClick={handleSkipDiagnostic}>Skip to activities</button>
-        )}
-        {showContinue && (
-          <button className="skip-step-btn" onClick={handleStartCourse} style={{ background: 'var(--color-primary)', color: 'var(--color-primary-text)' }}>
-            Continue to activities
-          </button>
-        )}
+        {loading === 'generating' && !progress?.activities?.length && <ThinkingSpinner text="Preparing your first activity..." />}
 
         {/* Completed activities */}
         {progress?.activities?.slice(0, progress.currentActivityIndex).map((a, ai) => {
@@ -337,24 +238,24 @@ export default function UnitChat() {
               <div className="chat-section-heading" role="separator">
                 {TYPE_LABELS[a.type] || a.type}: {a.goal}
               </div>
-              <InstructionMessage text={a.instruction} />
+              <InstructionMessage text={a.instruction} rubricCriteria={a.rubricCriteria} />
               {renderTimeline(a, drafts)}
             </div>
           );
         })}
 
         {/* Current activity */}
-        {activity && !isCompleted && (
+        {activity && !isUnitDone && (
           <>
             <div className="chat-section-heading" role="separator">
               {TYPE_LABELS[activity.type] || activity.type}: {activity.goal}
             </div>
-            <InstructionMessage text={activity.instruction} />
+            <InstructionMessage text={activity.instruction} rubricCriteria={activity.rubricCriteria} />
             {renderTimeline(activity, activityDrafts, true, handleDispute, handleRecord)}
 
             {loading === 'recording' && <ThinkingSpinner text="Evaluating your work..." />}
             {loading === 'qa' && <ThinkingSpinner />}
-            {loading === 'generating' && <ThinkingSpinner text="Preparing next activity..." />}
+            {loading === 'generating' && progress?.activities?.length > 0 && <ThinkingSpinner text="Preparing next activity..." />}
 
             {!activityDrafts.length && !loading && (
               <div style={{ textAlign: 'center', margin: '8px 0' }}>
@@ -369,24 +270,33 @@ export default function UnitChat() {
                 Continue to next activity ({remaining} remaining)
               </button>
             )}
+            {isPassed && remaining <= 0 && (
+              <div className="msg msg-response" style={{ textAlign: 'center' }}>
+                <p>Unit complete! Return to the course page to retake the summative assessment.</p>
+                <button className="primary-btn" onClick={() => navigate(courseGroup ? `/courses/${courseGroup.courseId}` : '/courses')}>
+                  Back to Course
+                </button>
+              </div>
+            )}
           </>
         )}
 
-        {/* Completion */}
-        {isCompleted && <CompletionSummary unit={unit} progress={progress} />}
+        {/* Unit done */}
+        {isUnitDone && (
+          <div className="msg msg-response" style={{ textAlign: 'center' }}>
+            <h3>Unit Complete</h3>
+            <p>Return to the course page to continue your journey or retake the summative.</p>
+            <button className="primary-btn" onClick={() => navigate(courseGroup ? `/courses/${courseGroup.courseId}` : '/courses')}>
+              Back to Course
+            </button>
+          </div>
+        )}
 
         {error && <div className="msg msg-response" role="alert" aria-live="assertive" style={{ color: 'var(--color-warning)' }}>{error}</div>}
       </ChatArea>
 
-      {/* Compose bar */}
-      {diagnostic.phase === 'activity' && !diagnostic.result && !loading && (
-        <ComposeBar
-          placeholder="Describe what you know..."
-          onSend={handleDiagnosticSend}
-          disabled={!!loading}
-        />
-      )}
-      {activity && !isCompleted && !loading && (
+      {/* Compose bar for Q&A */}
+      {activity && !isUnitDone && !loading && (
         <ComposeBar
           placeholder="Ask a question about this activity..."
           onSend={handleActivitySend}
@@ -399,7 +309,6 @@ export default function UnitChat() {
 
 /** Render timeline of drafts + Q&A messages for an activity. */
 function renderTimeline(activity, drafts, isCurrent = false, onDispute, onRerecord) {
-  // Merge drafts + messages, sort by timestamp
   const items = [];
   for (const d of drafts) {
     items.push({ type: 'draft', data: d, ts: d.timestamp });

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -215,6 +215,9 @@ export default function UnitsList() {
       {/* Rubric review phase */}
       {phase === COURSE_PHASES.RUBRIC_REVIEW && summative && (
         <ChatArea>
+          <div className="msg msg-response" style={{ fontSize: '0.85rem' }}>
+            You'll take this assessment twice — once now as a baseline, and again after learning to show mastery. Your first attempt reveals where you are so we can build a personalized path forward.
+          </div>
           <div className="chat-section-heading" role="separator">Assessment Overview</div>
           <SummativeCard summative={summative} />
           {reviewMessages.map((m, i) => (
@@ -281,6 +284,9 @@ export default function UnitsList() {
       {/* Formative learning — show unit cards */}
       {phase === COURSE_PHASES.FORMATIVE_LEARNING && (
         <>
+          <div className="msg msg-response" style={{ fontSize: '0.85rem', margin: 'var(--space)' }}>
+            Based on your baseline, here's a personalized learning journey. Complete these activities, then retake the assessment to demonstrate mastery.
+          </div>
           {latestAttempt && (
             <div style={{ padding: '0 var(--space)' }}>
               <div className="chat-section-heading" role="separator">Assessment Results</div>

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -216,7 +216,7 @@ export default function UnitsList() {
       {phase === COURSE_PHASES.RUBRIC_REVIEW && summative && (
         <ChatArea>
           <div className="msg msg-response" style={{ fontSize: '0.85rem' }}>
-            You'll take this assessment twice — once now as a baseline, and again after learning to show mastery. Your first attempt reveals where you are so we can build a personalized path forward.
+            Take this assessment. We'll use it to build your learning path.
           </div>
           <div className="chat-section-heading" role="separator">Assessment Overview</div>
           <SummativeCard summative={summative} />
@@ -285,7 +285,7 @@ export default function UnitsList() {
       {phase === COURSE_PHASES.FORMATIVE_LEARNING && (
         <>
           <div className="msg msg-response" style={{ fontSize: '0.85rem', margin: 'var(--space)' }}>
-            Based on your baseline, here's a personalized learning journey. Complete these activities, then retake the assessment to demonstrate mastery.
+            Here's your learning path. Retake the assessment when you're ready.
           </div>
           {latestAttempt && (
             <div style={{ padding: '0 var(--space)' }}>

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -14,6 +14,7 @@ import {
 } from '../lib/unitEngine.js';
 import { updateProfileOnMasteryInBackground } from '../lib/profileQueue.js';
 
+import { useModal } from '../contexts/ModalContext.jsx';
 import ChatArea from '../components/chat/ChatArea.jsx';
 import ThinkingSpinner from '../components/chat/ThinkingSpinner.jsx';
 import SummativeCard from '../components/chat/SummativeCard.jsx';
@@ -23,6 +24,7 @@ import DraftMessage from '../components/chat/DraftMessage.jsx';
 import ComposeBar from '../components/chat/ComposeBar.jsx';
 import UserMessage from '../components/chat/UserMessage.jsx';
 import AssistantMessage from '../components/chat/AssistantMessage.jsx';
+import ConfirmModal from '../components/modals/ConfirmModal.jsx';
 
 export default function UnitsList() {
   const { courseGroupId } = useParams();
@@ -30,7 +32,32 @@ export default function UnitsList() {
   const { state } = useApp();
   const { courseGroups, allProgress } = state;
 
+  const { show: showModal } = useModal();
   const group = courseGroups.find(cg => cg.courseId === courseGroupId);
+
+  const handleResetCourse = () => {
+    showModal(
+      <ConfirmModal
+        title="Reset Course?"
+        message="This will delete all progress for this course — assessment, journey, and activities. You'll start from scratch."
+        confirmLabel="Reset Course"
+        onConfirm={async () => {
+          const { deleteCourseProgress } = await import('../../js/storage.js');
+          await deleteCourseProgress(courseGroupId);
+          // Reset local state
+          setPhase(null);
+          setSummative(null);
+          setJourney(null);
+          setAttempts([]);
+          setReviewMessages([]);
+          setCaptures([]);
+          setCurrentStep(0);
+          // Reload — will trigger summative generation
+          window.location.reload();
+        }}
+      />
+    );
+  };
 
   const [phase, setPhase] = useState(null);
   const [summative, setSummative] = useState(null);
@@ -181,6 +208,7 @@ export default function UnitsList() {
         <div className="course-header-info">
           <h2>{group.name}</h2>
         </div>
+        {phase && <button className="reset-btn" onClick={handleResetCourse} aria-label="Reset course" title="Reset course">&#8635;</button>}
       </div>
 
       {/* Setup phase */}

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -208,7 +208,7 @@ export default function UnitsList() {
       {/* Setup phase */}
       {(phase === COURSE_PHASES.SUMMATIVE_SETUP || loading === 'summative') && (
         <ChatArea>
-          <RotatingSpinner />
+          <ThinkingSpinner />
         </ChatArea>
       )}
 
@@ -375,20 +375,3 @@ export default function UnitsList() {
   );
 }
 
-const LOADING_MESSAGES = [
-  'Sharpening pencils...',
-  'Consulting the learning gods...',
-  'Brewing assessment tea...',
-  'Warming up the neurons...',
-  'Folding paper airplanes...',
-  'Rearranging sticky notes...',
-];
-
-function RotatingSpinner() {
-  const [index, setIndex] = useState(0);
-  useEffect(() => {
-    const timer = setInterval(() => setIndex(i => (i + 1) % LOADING_MESSAGES.length), 3000);
-    return () => clearInterval(timer);
-  }, []);
-  return <ThinkingSpinner text={LOADING_MESSAGES[index]} />;
-}

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -31,7 +31,7 @@ export default function UnitsList() {
   const navigate = useNavigate();
   const { state } = useApp();
   const { courseGroups, allProgress } = state;
-
+  const { dispatch } = useApp();
   const { show: showModal } = useModal();
   const group = courseGroups.find(cg => cg.courseId === courseGroupId);
 
@@ -44,6 +44,9 @@ export default function UnitsList() {
         onConfirm={async () => {
           const { deleteCourseProgress } = await import('../../js/storage.js');
           await deleteCourseProgress(courseGroupId);
+          // Clear unit progress from app state
+          const unitIds = (group.units || []).map(u => u.unitId);
+          for (const uid of unitIds) dispatch({ type: 'RESET_UNIT', unitId: uid });
           navigate('/courses');
         }}
       />

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -208,7 +208,14 @@ export default function UnitsList() {
       {/* Setup phase */}
       {(phase === COURSE_PHASES.SUMMATIVE_SETUP || loading === 'summative') && (
         <ChatArea>
-          <ThinkingSpinner text="Designing your assessment..." />
+          <ThinkingSpinner text={[
+            'Sharpening pencils...',
+            'Calibrating the rubric machine...',
+            'Consulting the learning gods...',
+            'Brewing assessment tea...',
+            'Warming up the neurons...',
+            'Folding paper airplanes... wait, wrong task...',
+          ][Math.floor(Math.random() * 6)]} />
         </ChatArea>
       )}
 

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -1,5 +1,27 @@
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApp } from '../contexts/AppContext.jsx';
+import { COURSE_PHASES } from '../lib/constants.js';
+import {
+  getSummative, getCoursePhase, getJourney, getSummativeAttempts,
+  getRubricReviewState,
+} from '../../js/storage.js';
+import {
+  initCourse, sendRubricReviewMessage, confirmRubric,
+  recordSummativeCapture, submitSummativeAttempt,
+  generateGapAndJourney, requestSummativeRetake,
+  generateRemediationActivities,
+} from '../lib/unitEngine.js';
+import { updateProfileOnMasteryInBackground } from '../lib/profileQueue.js';
+
+import ChatArea from '../components/chat/ChatArea.jsx';
+import ThinkingSpinner from '../components/chat/ThinkingSpinner.jsx';
+import SummativeCard from '../components/chat/SummativeCard.jsx';
+import RubricFeedback from '../components/chat/RubricFeedback.jsx';
+import CaptureStep from '../components/chat/CaptureStep.jsx';
+import ComposeBar from '../components/chat/ComposeBar.jsx';
+import UserMessage from '../components/chat/UserMessage.jsx';
+import AssistantMessage from '../components/chat/AssistantMessage.jsx';
 
 export default function UnitsList() {
   const { courseGroupId } = useParams();
@@ -8,9 +30,142 @@ export default function UnitsList() {
   const { courseGroups, allProgress } = state;
 
   const group = courseGroups.find(cg => cg.courseId === courseGroupId);
-  if (!group) return <p>Course not found.</p>;
 
-  const groupUnits = group.units || [group];
+  const [phase, setPhase] = useState(null);
+  const [summative, setSummative] = useState(null);
+  const [journey, setJourney] = useState(null);
+  const [attempts, setAttempts] = useState([]);
+  const [reviewMessages, setReviewMessages] = useState([]);
+  const [captures, setCaptures] = useState([]);
+  const [loading, setLoading] = useState('');
+  const [error, setError] = useState('');
+
+  // Load course state on mount
+  useEffect(() => {
+    if (!group) return;
+    let cancelled = false;
+
+    (async () => {
+      const existingPhase = await getCoursePhase(courseGroupId);
+      if (cancelled) return;
+
+      if (existingPhase) {
+        setPhase(existingPhase);
+        const s = await getSummative(courseGroupId);
+        if (s) setSummative(s);
+        const j = await getJourney(courseGroupId);
+        if (j) setJourney(j);
+        const a = await getSummativeAttempts(courseGroupId);
+        setAttempts(a);
+        const rs = await getRubricReviewState(courseGroupId);
+        if (rs?.messages) setReviewMessages(rs.messages);
+      } else {
+        // First time: generate summative
+        setLoading('summative');
+        try {
+          const s = await initCourse(group);
+          if (cancelled) return;
+          setSummative(s);
+          setPhase(COURSE_PHASES.RUBRIC_REVIEW);
+        } catch (e) {
+          if (!cancelled) setError(e.message || 'Failed to generate summative.');
+        }
+        if (!cancelled) setLoading('');
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [courseGroupId]);
+
+  // Rubric review conversation
+  const handleReviewSend = useCallback(async (text) => {
+    if (!summative || !group) return;
+    setLoading('review');
+    try {
+      const { result, summative: newSummative, messages } = await sendRubricReviewMessage(
+        courseGroupId, text, summative, reviewMessages, group
+      );
+      setReviewMessages(messages);
+      if (newSummative) setSummative(newSummative);
+      if (result.done) {
+        await confirmRubric(courseGroupId);
+        setPhase(COURSE_PHASES.BASELINE_ATTEMPT);
+      }
+    } catch (e) {
+      setError(e.message || 'Failed to send message.');
+    }
+    setLoading('');
+  }, [courseGroupId, summative, reviewMessages, group]);
+
+  // Skip rubric review
+  const handleSkipReview = useCallback(async () => {
+    await confirmRubric(courseGroupId);
+    setPhase(COURSE_PHASES.BASELINE_ATTEMPT);
+  }, [courseGroupId]);
+
+  // Capture a summative step
+  const handleSummativeCapture = useCallback(async (stepIndex) => {
+    setLoading('capturing');
+    try {
+      const capture = await recordSummativeCapture(courseGroupId, stepIndex);
+      const newCaptures = [...captures, capture];
+      setCaptures(newCaptures);
+
+      // Auto-submit when all steps captured
+      if (newCaptures.length === (summative?.task?.steps?.length || 0)) {
+        setLoading('assessing');
+        const { attempt, mastery } = await submitSummativeAttempt(courseGroupId, group, newCaptures);
+        setAttempts(prev => [...prev, attempt]);
+        setCaptures([]);
+
+        if (mastery) {
+          setPhase(COURSE_PHASES.COMPLETED);
+          // Update profile for mastery
+          updateProfileOnMasteryInBackground(group, attempt, []);
+        } else if (attempt.isBaseline) {
+          // Baseline done → generate gap + journey
+          setLoading('journey');
+          const { journey: j } = await generateGapAndJourney(courseGroupId, group);
+          setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
+          setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
+        } else {
+          // Retake didn't achieve mastery → generate remediation activities
+          setLoading('journey');
+          const weakCriteria = (attempt.criteriaScores || [])
+            .filter(cs => cs.score < 0.51)
+            .map(cs => cs.criterion);
+          const { journey: j } = await generateRemediationActivities(courseGroupId, group, weakCriteria);
+          setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
+          setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
+        }
+      }
+    } catch (e) {
+      setError(e.message || 'Capture failed.');
+    }
+    setLoading('');
+  }, [courseGroupId, captures, summative, group]);
+
+  // Request summative retake
+  const handleRetake = useCallback(async () => {
+    await requestSummativeRetake(courseGroupId);
+    setCaptures([]);
+    setPhase(COURSE_PHASES.SUMMATIVE_RETAKE);
+  }, [courseGroupId]);
+
+  // After baseline, start journey
+  const handleStartJourney = useCallback(async () => {
+    setLoading('journey');
+    try {
+      const { journey: j } = await generateGapAndJourney(courseGroupId, group);
+      setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
+      setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
+    } catch (e) {
+      setError(e.message || 'Failed to generate journey.');
+    }
+    setLoading('');
+  }, [courseGroupId, group]);
+
+  if (!group) return <p>Course not found.</p>;
 
   function statusIcon(status) {
     if (status === 'completed') return '\u2713';
@@ -18,44 +173,156 @@ export default function UnitsList() {
     return '\u25CB';
   }
 
+  const latestAttempt = attempts[attempts.length - 1];
+  const journeyUnits = journey?.plan?.units || [];
+
   return (
-    <>
-      <div className="course-header" style={{ marginBottom: 'var(--space)' }}>
+    <div className="course-layout">
+      <div className="course-header">
         <button className="back-btn" aria-label="Back to courses" onClick={() => navigate('/courses')}>&larr;</button>
         <div className="course-header-info">
           <h2>{group.name}</h2>
         </div>
       </div>
-      <div className="course-list" role="list">
-        {groupUnits.map((u, i) => {
-          const progress = allProgress[u.unitId];
-          const status = progress?.status || 'not_started';
-          const locked = u.dependsOn && allProgress[u.dependsOn]?.status !== 'completed';
-          const icon = statusIcon(status);
-          const mins = (u.learningObjectives?.length || 1) * 5 + 2;
-          const isRequired = !u.optional;
-          return (
-            <button
-              key={u.unitId}
-              className={`course-card${locked ? ' locked' : ''} stagger-item`}
-              style={{ animationDelay: `${i * 40}ms` }}
-              role="listitem"
-              onClick={() => !locked && navigate(`/unit/${u.unitId}`)}
-              disabled={locked}
-            >
-              <span className="course-status" aria-hidden="true">{icon}</span>
-              <div className="course-info">
-                <strong>{u.name}</strong>
-                {u.description && <p>{u.description}</p>}
-                <small>
-                  {locked ? 'Complete prerequisite first' : `~${mins} min`}
-                  {isRequired ? '' : ' \u00b7 Optional'}
-                </small>
-              </div>
+
+      {/* Summative phases */}
+      {(phase === COURSE_PHASES.SUMMATIVE_SETUP || loading === 'summative') && (
+        <ChatArea>
+          <ThinkingSpinner text="Designing your assessment..." />
+        </ChatArea>
+      )}
+
+      {phase === COURSE_PHASES.RUBRIC_REVIEW && summative && (
+        <ChatArea>
+          <SummativeCard summative={summative} />
+          {reviewMessages.map((m, i) => (
+            m.role === 'user'
+              ? <UserMessage key={i} content={m.content} />
+              : <AssistantMessage key={i} content={m.content} />
+          ))}
+          {loading === 'review' && <ThinkingSpinner />}
+          {!loading && (
+            <button className="skip-step-btn" onClick={handleSkipReview} style={{ marginTop: '8px' }}>
+              Skip to assessment
             </button>
-          );
-        })}
-      </div>
-    </>
+          )}
+        </ChatArea>
+      )}
+
+      {(phase === COURSE_PHASES.BASELINE_ATTEMPT || phase === COURSE_PHASES.SUMMATIVE_RETAKE) && summative && (
+        <ChatArea>
+          {phase === COURSE_PHASES.SUMMATIVE_RETAKE && (
+            <div className="chat-section-heading" role="separator">Summative Retake</div>
+          )}
+          <SummativeCard summative={summative} />
+          <CaptureStep
+            steps={summative.task?.steps || []}
+            captures={captures}
+            onCapture={handleSummativeCapture}
+            loading={!!loading}
+          />
+          {loading === 'capturing' && <ThinkingSpinner text="Capturing..." />}
+          {loading === 'assessing' && <ThinkingSpinner text="Evaluating your work..." />}
+          {loading === 'journey' && <ThinkingSpinner text="Building your learning journey..." />}
+        </ChatArea>
+      )}
+
+      {phase === COURSE_PHASES.GAP_ANALYSIS && (
+        <ChatArea>
+          <ThinkingSpinner text="Analyzing your results..." />
+        </ChatArea>
+      )}
+
+      {phase === COURSE_PHASES.JOURNEY_GENERATION && (
+        <ChatArea>
+          <ThinkingSpinner text="Building your learning journey..." />
+        </ChatArea>
+      )}
+
+      {/* Formative learning phase — show unit cards */}
+      {phase === COURSE_PHASES.FORMATIVE_LEARNING && (
+        <>
+          {/* Baseline/latest attempt feedback */}
+          {latestAttempt && (
+            <div style={{ padding: '0 var(--space)' }}>
+              <RubricFeedback attempt={latestAttempt} />
+            </div>
+          )}
+
+          {/* Retake button */}
+          <div style={{ padding: '0 var(--space)', marginBottom: 'var(--space)' }}>
+            <button className="primary-btn" onClick={handleRetake} style={{ width: '100%' }}>
+              Retake Summative Assessment
+            </button>
+          </div>
+
+          {/* Journey units */}
+          <div className="course-list" role="list">
+            {journeyUnits.map((ju, i) => {
+              const unitDef = group.units?.find(u => u.unitId === ju.unitId);
+              const progress = allProgress[ju.unitId];
+              const status = progress?.status || 'not_started';
+              const actCount = ju.activities?.length || 0;
+              const criteria = ju.activities?.flatMap(a => a.rubricCriteria || []).filter((v, idx, arr) => arr.indexOf(v) === idx) || [];
+
+              return (
+                <button
+                  key={ju.unitId}
+                  className="course-card stagger-item"
+                  style={{ animationDelay: `${i * 40}ms` }}
+                  role="listitem"
+                  onClick={() => navigate(`/unit/${ju.unitId}`)}
+                >
+                  <span className="course-status" aria-hidden="true">{statusIcon(status)}</span>
+                  <div className="course-info">
+                    <strong>{unitDef?.name || ju.unitId}</strong>
+                    {unitDef?.description && <p>{unitDef.description}</p>}
+                    <small>{actCount} activit{actCount !== 1 ? 'ies' : 'y'}</small>
+                    {criteria.length > 0 && (
+                      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '3px', marginTop: '3px' }}>
+                        {criteria.map((c, ci) => (
+                          <span key={ci} style={{
+                            fontSize: '0.65rem', padding: '1px 5px', borderRadius: '6px',
+                            background: 'var(--color-primary-light, #e8f0fe)', color: 'var(--color-primary, #1a73e8)',
+                          }}>{c}</span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Completed */}
+      {phase === COURSE_PHASES.COMPLETED && (
+        <ChatArea>
+          {latestAttempt && <RubricFeedback attempt={latestAttempt} />}
+          <div className="completion-summary msg msg-response">
+            <h3>Mastery Achieved!</h3>
+            <div className="completion-stats">
+              <span>{attempts.length} attempt{attempts.length !== 1 ? 's' : ''}</span>
+              <span>{journeyUnits.length} unit{journeyUnits.length !== 1 ? 's' : ''}</span>
+            </div>
+            <div className="action-bar">
+              <button className="primary-btn" onClick={() => navigate('/courses')}>Next Course</button>
+            </div>
+          </div>
+        </ChatArea>
+      )}
+
+      {error && <div style={{ padding: '8px var(--space)', color: 'var(--color-warning)' }} role="alert">{error}</div>}
+
+      {/* Compose bar for rubric review */}
+      {phase === COURSE_PHASES.RUBRIC_REVIEW && !loading && (
+        <ComposeBar
+          placeholder="Questions or feedback on the rubric..."
+          onSend={handleReviewSend}
+          disabled={!!loading}
+        />
+      )}
+    </div>
   );
 }

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -44,16 +44,7 @@ export default function UnitsList() {
         onConfirm={async () => {
           const { deleteCourseProgress } = await import('../../js/storage.js');
           await deleteCourseProgress(courseGroupId);
-          // Reset local state
-          setPhase(null);
-          setSummative(null);
-          setJourney(null);
-          setAttempts([]);
-          setReviewMessages([]);
-          setCaptures([]);
-          setCurrentStep(0);
-          // Reload — will trigger summative generation
-          window.location.reload();
+          navigate('/courses');
         }}
       />
     );

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -202,9 +202,11 @@ export default function UnitsList() {
           ))}
           {loading === 'review' && <ThinkingSpinner />}
           {!loading && (
-            <button className="skip-step-btn" onClick={handleSkipReview} style={{ marginTop: '8px' }}>
-              Start assessment
-            </button>
+            <div style={{ textAlign: 'center', margin: '8px 0' }}>
+              <button className="primary-btn" onClick={handleSkipReview}>
+                Start Assessment
+              </button>
+            </div>
           )}
         </ChatArea>
       )}

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -208,14 +208,7 @@ export default function UnitsList() {
       {/* Setup phase */}
       {(phase === COURSE_PHASES.SUMMATIVE_SETUP || loading === 'summative') && (
         <ChatArea>
-          <ThinkingSpinner text={[
-            'Sharpening pencils...',
-            'Calibrating the rubric machine...',
-            'Consulting the learning gods...',
-            'Brewing assessment tea...',
-            'Warming up the neurons...',
-            'Folding paper airplanes... wait, wrong task...',
-          ][Math.floor(Math.random() * 6)]} />
+          <RotatingSpinner />
         </ChatArea>
       )}
 
@@ -380,4 +373,22 @@ export default function UnitsList() {
       )}
     </div>
   );
+}
+
+const LOADING_MESSAGES = [
+  'Sharpening pencils...',
+  'Consulting the learning gods...',
+  'Brewing assessment tea...',
+  'Warming up the neurons...',
+  'Folding paper airplanes...',
+  'Rearranging sticky notes...',
+];
+
+function RotatingSpinner() {
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setIndex(i => (i + 1) % LOADING_MESSAGES.length), 3000);
+    return () => clearInterval(timer);
+  }, []);
+  return <ThinkingSpinner text={LOADING_MESSAGES[index]} />;
 }

--- a/src/pages/UnitsList.jsx
+++ b/src/pages/UnitsList.jsx
@@ -18,7 +18,8 @@ import ChatArea from '../components/chat/ChatArea.jsx';
 import ThinkingSpinner from '../components/chat/ThinkingSpinner.jsx';
 import SummativeCard from '../components/chat/SummativeCard.jsx';
 import RubricFeedback from '../components/chat/RubricFeedback.jsx';
-import CaptureStep from '../components/chat/CaptureStep.jsx';
+import InstructionMessage from '../components/chat/InstructionMessage.jsx';
+import DraftMessage from '../components/chat/DraftMessage.jsx';
 import ComposeBar from '../components/chat/ComposeBar.jsx';
 import UserMessage from '../components/chat/UserMessage.jsx';
 import AssistantMessage from '../components/chat/AssistantMessage.jsx';
@@ -37,6 +38,7 @@ export default function UnitsList() {
   const [attempts, setAttempts] = useState([]);
   const [reviewMessages, setReviewMessages] = useState([]);
   const [captures, setCaptures] = useState([]);
+  const [currentStep, setCurrentStep] = useState(0);
   const [loading, setLoading] = useState('');
   const [error, setError] = useState('');
 
@@ -60,7 +62,6 @@ export default function UnitsList() {
         const rs = await getRubricReviewState(courseGroupId);
         if (rs?.messages) setReviewMessages(rs.messages);
       } else {
-        // First time: generate summative
         setLoading('summative');
         try {
           const s = await initCourse(group);
@@ -90,6 +91,8 @@ export default function UnitsList() {
       if (result.done) {
         await confirmRubric(courseGroupId);
         setPhase(COURSE_PHASES.BASELINE_ATTEMPT);
+        setCurrentStep(0);
+        setCaptures([]);
       }
     } catch (e) {
       setError(e.message || 'Failed to send message.');
@@ -97,39 +100,40 @@ export default function UnitsList() {
     setLoading('');
   }, [courseGroupId, summative, reviewMessages, group]);
 
-  // Skip rubric review
   const handleSkipReview = useCallback(async () => {
     await confirmRubric(courseGroupId);
+    setCurrentStep(0);
+    setCaptures([]);
     setPhase(COURSE_PHASES.BASELINE_ATTEMPT);
   }, [courseGroupId]);
 
-  // Capture a summative step
-  const handleSummativeCapture = useCallback(async (stepIndex) => {
+  // Capture current summative step, then advance to next
+  const handleStepCapture = useCallback(async () => {
     setLoading('capturing');
     try {
-      const capture = await recordSummativeCapture(courseGroupId, stepIndex);
+      const capture = await recordSummativeCapture(courseGroupId, currentStep);
       const newCaptures = [...captures, capture];
       setCaptures(newCaptures);
 
-      // Auto-submit when all steps captured
-      if (newCaptures.length === (summative?.task?.steps?.length || 0)) {
+      const totalSteps = summative?.task?.steps?.length || 0;
+
+      if (newCaptures.length === totalSteps) {
+        // All steps captured — submit for assessment
         setLoading('assessing');
         const { attempt, mastery } = await submitSummativeAttempt(courseGroupId, group, newCaptures);
         setAttempts(prev => [...prev, attempt]);
         setCaptures([]);
+        setCurrentStep(0);
 
         if (mastery) {
           setPhase(COURSE_PHASES.COMPLETED);
-          // Update profile for mastery
           updateProfileOnMasteryInBackground(group, attempt, []);
         } else if (attempt.isBaseline) {
-          // Baseline done → generate gap + journey
           setLoading('journey');
           const { journey: j } = await generateGapAndJourney(courseGroupId, group);
           setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
           setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
         } else {
-          // Retake didn't achieve mastery → generate remediation activities
           setLoading('journey');
           const weakCriteria = (attempt.criteriaScores || [])
             .filter(cs => cs.score < 0.51)
@@ -138,32 +142,22 @@ export default function UnitsList() {
           setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
           setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
         }
+      } else {
+        // Advance to next step
+        setCurrentStep(newCaptures.length);
       }
     } catch (e) {
       setError(e.message || 'Capture failed.');
     }
     setLoading('');
-  }, [courseGroupId, captures, summative, group]);
+  }, [courseGroupId, currentStep, captures, summative, group]);
 
-  // Request summative retake
   const handleRetake = useCallback(async () => {
     await requestSummativeRetake(courseGroupId);
     setCaptures([]);
+    setCurrentStep(0);
     setPhase(COURSE_PHASES.SUMMATIVE_RETAKE);
   }, [courseGroupId]);
-
-  // After baseline, start journey
-  const handleStartJourney = useCallback(async () => {
-    setLoading('journey');
-    try {
-      const { journey: j } = await generateGapAndJourney(courseGroupId, group);
-      setJourney({ plan: j, phase: COURSE_PHASES.FORMATIVE_LEARNING });
-      setPhase(COURSE_PHASES.FORMATIVE_LEARNING);
-    } catch (e) {
-      setError(e.message || 'Failed to generate journey.');
-    }
-    setLoading('');
-  }, [courseGroupId, group]);
 
   if (!group) return <p>Course not found.</p>;
 
@@ -175,6 +169,10 @@ export default function UnitsList() {
 
   const latestAttempt = attempts[attempts.length - 1];
   const journeyUnits = journey?.plan?.units || [];
+  const steps = summative?.task?.steps || [];
+  const isBaseline = phase === COURSE_PHASES.BASELINE_ATTEMPT;
+  const isRetake = phase === COURSE_PHASES.SUMMATIVE_RETAKE;
+  const isSummativeActive = isBaseline || isRetake;
 
   return (
     <div className="course-layout">
@@ -185,15 +183,17 @@ export default function UnitsList() {
         </div>
       </div>
 
-      {/* Summative phases */}
+      {/* Setup phase */}
       {(phase === COURSE_PHASES.SUMMATIVE_SETUP || loading === 'summative') && (
         <ChatArea>
           <ThinkingSpinner text="Designing your assessment..." />
         </ChatArea>
       )}
 
+      {/* Rubric review phase */}
       {phase === COURSE_PHASES.RUBRIC_REVIEW && summative && (
         <ChatArea>
+          <div className="chat-section-heading" role="separator">Assessment Overview</div>
           <SummativeCard summative={summative} />
           {reviewMessages.map((m, i) => (
             m.role === 'user'
@@ -203,60 +203,71 @@ export default function UnitsList() {
           {loading === 'review' && <ThinkingSpinner />}
           {!loading && (
             <button className="skip-step-btn" onClick={handleSkipReview} style={{ marginTop: '8px' }}>
-              Skip to assessment
+              Start assessment
             </button>
           )}
         </ChatArea>
       )}
 
-      {(phase === COURSE_PHASES.BASELINE_ATTEMPT || phase === COURSE_PHASES.SUMMATIVE_RETAKE) && summative && (
+      {/* Summative attempt — step by step */}
+      {isSummativeActive && summative && (
         <ChatArea>
-          {phase === COURSE_PHASES.SUMMATIVE_RETAKE && (
-            <div className="chat-section-heading" role="separator">Summative Retake</div>
+          <div className="chat-section-heading" role="separator">
+            {isBaseline ? 'Diagnostic Assessment' : 'Summative Assessment'}
+          </div>
+
+          {/* Completed steps */}
+          {captures.map((cap, i) => {
+            const step = steps[cap.stepIndex];
+            return (
+              <div key={i}>
+                <InstructionMessage text={step?.instruction} />
+                <DraftMessage draft={{ screenshotKey: cap.screenshotKey, url: cap.url, timestamp: Date.now() }} />
+              </div>
+            );
+          })}
+
+          {/* Current step */}
+          {currentStep < steps.length && !loading && (
+            <>
+              <InstructionMessage text={`Step ${currentStep + 1} of ${steps.length}: ${steps[currentStep].instruction}`} />
+              <div style={{ textAlign: 'center', margin: '8px 0' }}>
+                <button className="record-btn" onClick={handleStepCapture} aria-label="Capture screenshot">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: '-2px', marginRight: '6px' }}>
+                    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+                  </svg>
+                  Capture
+                </button>
+              </div>
+            </>
           )}
-          <SummativeCard summative={summative} />
-          <CaptureStep
-            steps={summative.task?.steps || []}
-            captures={captures}
-            onCapture={handleSummativeCapture}
-            loading={!!loading}
-          />
+
           {loading === 'capturing' && <ThinkingSpinner text="Capturing..." />}
           {loading === 'assessing' && <ThinkingSpinner text="Evaluating your work..." />}
           {loading === 'journey' && <ThinkingSpinner text="Building your learning journey..." />}
         </ChatArea>
       )}
 
-      {phase === COURSE_PHASES.GAP_ANALYSIS && (
-        <ChatArea>
-          <ThinkingSpinner text="Analyzing your results..." />
-        </ChatArea>
-      )}
-
-      {phase === COURSE_PHASES.JOURNEY_GENERATION && (
+      {(phase === COURSE_PHASES.GAP_ANALYSIS || phase === COURSE_PHASES.JOURNEY_GENERATION) && (
         <ChatArea>
           <ThinkingSpinner text="Building your learning journey..." />
         </ChatArea>
       )}
 
-      {/* Formative learning phase — show unit cards */}
+      {/* Formative learning — show unit cards */}
       {phase === COURSE_PHASES.FORMATIVE_LEARNING && (
         <>
-          {/* Baseline/latest attempt feedback */}
           {latestAttempt && (
             <div style={{ padding: '0 var(--space)' }}>
+              <div className="chat-section-heading" role="separator">Assessment Results</div>
               <RubricFeedback attempt={latestAttempt} />
             </div>
           )}
 
-          {/* Retake button */}
-          <div style={{ padding: '0 var(--space)', marginBottom: 'var(--space)' }}>
-            <button className="primary-btn" onClick={handleRetake} style={{ width: '100%' }}>
-              Retake Summative Assessment
-            </button>
+          <div style={{ padding: '0 var(--space)', margin: 'var(--space) 0' }}>
+            <div className="chat-section-heading" role="separator">Learning Journey</div>
           </div>
 
-          {/* Journey units */}
           <div className="course-list" role="list">
             {journeyUnits.map((ju, i) => {
               const unitDef = group.units?.find(u => u.unitId === ju.unitId);
@@ -293,12 +304,19 @@ export default function UnitsList() {
               );
             })}
           </div>
+
+          <div style={{ padding: '0 var(--space)', marginTop: 'var(--space)' }}>
+            <button className="primary-btn" onClick={handleRetake} style={{ width: '100%' }}>
+              Retake Summative Assessment
+            </button>
+          </div>
         </>
       )}
 
       {/* Completed */}
       {phase === COURSE_PHASES.COMPLETED && (
         <ChatArea>
+          <div className="chat-section-heading" role="separator">Summative Assessment</div>
           {latestAttempt && <RubricFeedback attempt={latestAttempt} />}
           <div className="completion-summary msg msg-response">
             <h3>Mastery Achieved!</h3>

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -203,6 +203,21 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
             <span>{capturing ? 'Capturing...' : messages.length <= 1 ? 'Looking at your work...' : 'Thinking...'}</span>
           </div>
         )}
+        {!profileDone && !thinking && !capturing && (
+          <div style={{ textAlign: 'center', margin: '8px 0' }}>
+            <button
+              className="record-btn"
+              onClick={captureScreenshot}
+              disabled={thinking || capturing || skipping}
+              aria-label="Capture screenshot"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: '-2px', marginRight: '6px' }}>
+                <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+              </svg>
+              Capture
+            </button>
+          </div>
+        )}
         {hasExchanged && !profileDone && !thinking && !capturing && (
           <button className="skip-step-btn" onClick={handleSkip} disabled={skipping}>
             {skipping ? 'Building your profile...' : 'Skip to courses'}
@@ -219,19 +234,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
         )}
       </div>
 
-      <div className="chat-compose" style={{ gap: '6px' }}>
-        <button
-          className="record-btn"
-          onClick={captureScreenshot}
-          disabled={thinking || capturing || skipping}
-          aria-label="Capture screenshot"
-          style={{ width: '100%' }}
-        >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: '-2px', marginRight: '6px' }}>
-            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
-          </svg>
-          Capture
-        </button>
+      <div className="chat-compose">
         <div className="compose-input-row">
           <label htmlFor="onboarding-input" className="sr-only">Your response</label>
           <textarea

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -186,11 +186,11 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   };
 
   return (
-    <div className="onboarding" style={{ paddingBottom: 0 }}>
+    <div className="onboarding" style={{ paddingBottom: 0, flex: 'none' }}>
       {!loggedIn && <span className="onboarding-step-label">Step 3 of 3 — Show Your Work</span>}
       {loggedIn && <span className="onboarding-step-label">Show us your work</span>}
 
-      <div className="chat" role="log" aria-label="Getting to know you" ref={chatRef}>
+      <div className="chat" role="log" aria-label="Getting to know you" ref={chatRef} style={{ flex: 'none', overflow: 'visible' }}>
         <div className="msg msg-response"><p dangerouslySetInnerHTML={{ __html: renderMd(initialGreeting) }} /></div>
         {messages.map((m, i) => (
           <div key={i} className={`msg ${m.role === 'user' ? 'msg-user' : 'msg-response'}`}>

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -222,14 +222,13 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
       <div className="chat-compose">
         <div className="compose-input-row">
           <button
-            className="record-btn"
+            className="send-btn"
             onClick={captureScreenshot}
             disabled={thinking || capturing || skipping}
             aria-label="Capture screenshot"
             title="Capture current page"
-            style={{ flexShrink: 0, padding: '6px 10px' }}
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
             </svg>
           </button>

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -21,7 +21,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const handleResize = useAutoResize();
 
   const firstName = data.name?.split(' ')[0] || data.name;
-  const initialGreeting = `Hi ${firstName} — let's see what you've got. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
+  const initialGreeting = `${firstName}, navigate to something that represents you professionally — LinkedIn, portfolio, a project — and hit **Capture**.`;
   const userMsgCount = messages.filter(m => m.role === 'user').length;
   const hasExchanged = userMsgCount >= 2;
 

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -20,7 +20,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const inputRef = useRef(null);
   const handleResize = useAutoResize();
 
-  const initialGreeting = `Hi, ${data.name}! I'd love to get to know you through your work. Navigate to a page that represents you professionally — your LinkedIn, personal site, portfolio, a project, or even a social profile — and hit **Capture**. Or just tell me what you're working toward.`;
+  const initialGreeting = `Hi, ${data.name}! I'd love to get to know you through your work. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
   const userMsgCount = messages.filter(m => m.role === 'user').length;
   const hasExchanged = userMsgCount >= 2;
 

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -60,8 +60,9 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
         setProfileDone(true);
       }
     } catch (e) {
-      console.warn('Onboarding conversation failed:', e);
-      setMessages(prev => [...prev, { role: 'assistant', content: JSON.stringify({ message: "Sorry, something went wrong. You can try again or skip to courses." }) }]);
+      console.error('[1111] Onboarding conversation failed:', e?.message || e, e?.stack || '');
+      const detail = e?.message || 'Unknown error';
+      setMessages(prev => [...prev, { role: 'assistant', content: JSON.stringify({ message: `Something went wrong: ${detail}` }) }]);
     }
     setThinking(false);
   };
@@ -123,7 +124,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
       setCapturing(false);
       await callAgent(newMessages);
     } catch (e) {
-      console.warn('Screenshot capture failed:', e);
+      console.error('[1111] Screenshot capture failed:', e?.message || e, e?.stack || '');
       setMessages(prev => [...prev, {
         role: 'assistant',
         content: JSON.stringify({ message: `Capture failed: ${e.message || 'Unknown error'}. Make sure you have a webpage open in the main browser window.` })
@@ -148,7 +149,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
           await saveLearnerProfileSummary(result.summary);
           syncInBackground('profile', 'profileSummary');
         } catch (e) {
-          console.warn('Profile creation on skip failed:', e);
+          console.error('[1111] Profile creation on skip failed:', e?.message || e);
         }
         setSkipping(false);
       }

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -39,11 +39,24 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const callAgent = async (newMessages) => {
     setThinking(true);
     try {
-      const msgs = newMessages.map((m, i) =>
-        i === 0 && m.role === 'user' && typeof m.content === 'string'
-          ? { role: 'user', content: `My name is ${data.name}. ${m.content}` }
-          : m
-      );
+      // Clean messages for API: strip extra props, extract text from assistant JSON
+      const msgs = newMessages.map((m, i) => {
+        if (m.role === 'assistant') {
+          // Assistant messages are stored as JSON strings — extract just the message text
+          try {
+            const parsed = JSON.parse(m.content);
+            return { role: 'assistant', content: parsed.message || m.content };
+          } catch {
+            return { role: 'assistant', content: m.content };
+          }
+        }
+        // User messages: strip internal props, keep content (string or content array)
+        const clean = { role: 'user', content: m.content };
+        if (i === 0 && typeof m.content === 'string') {
+          clean.content = `My name is ${data.name}. ${m.content}`;
+        }
+        return clean;
+      });
       // Use vision model since messages may contain screenshots
       const result = await orchestrator.converse('onboarding-conversation', msgs, 1024, { model: MODEL_HEAVY });
 
@@ -90,10 +103,11 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
         if (!granted) throw new Error('Permission needed to capture screenshots.');
       }
 
-      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      // Query the last focused window (not the side panel window)
+      const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
       const pageUrl = tab?.url || '';
-      if (!pageUrl || pageUrl.startsWith('chrome://') || pageUrl.startsWith('about:')) {
-        throw new Error('Navigate to a webpage before capturing.');
+      if (!pageUrl || pageUrl.startsWith('chrome://') || pageUrl.startsWith('chrome-extension://') || pageUrl.startsWith('about:') || pageUrl.startsWith('edge://')) {
+        throw new Error('Open a webpage in your browser first, then hit Capture.');
       }
 
       const response = await chrome.runtime.sendMessage({ type: 'captureScreenshot' });

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -219,27 +219,27 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
         )}
       </div>
 
-      <div className="chat-compose">
+      <div className="chat-compose" style={{ gap: '6px' }}>
+        <button
+          className="record-btn"
+          onClick={captureScreenshot}
+          disabled={thinking || capturing || skipping}
+          aria-label="Capture screenshot"
+          style={{ width: '100%' }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" style={{ verticalAlign: '-2px', marginRight: '6px' }}>
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+          </svg>
+          Capture
+        </button>
         <div className="compose-input-row">
-          <button
-            className="send-btn"
-            onClick={captureScreenshot}
-            disabled={thinking || capturing || skipping}
-            aria-label="Capture screenshot"
-            title="Capture current page"
-            style={{ height: 'auto', alignSelf: 'stretch' }}
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
-            </svg>
-          </button>
           <label htmlFor="onboarding-input" className="sr-only">Your response</label>
           <textarea
             ref={inputRef}
             id="onboarding-input"
             className="chat-input"
             rows={1}
-            placeholder={profileDone ? 'Say more or ask a question...' : 'Or type a message...'}
+            placeholder="Add a message..."
             value={input}
             onChange={(e) => { setInput(e.target.value); handleResize(e); }}
             onKeyDown={(e) => {

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -201,7 +201,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
         {(thinking || capturing) && (
           <div className="msg msg-response" role="status" aria-live="polite">
             <span className="loading-spinner-inline" aria-hidden="true" />
-            <span>{capturing ? 'Capturing...' : messages.length <= 1 ? 'Looking at your work...' : 'Thinking...'}</span>
+            <span>{capturing ? 'Capturing...' : 'Thinking...'}</span>
           </div>
         )}
         {!profileDone && !thinking && !capturing && (

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -20,7 +20,8 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const inputRef = useRef(null);
   const handleResize = useAutoResize();
 
-  const initialGreeting = `Hi, ${data.name}! I'd love to get to know you through your work. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
+  const firstName = data.name?.split(' ')[0] || data.name;
+  const initialGreeting = `Hi, ${firstName}! I'd love to get to know you through your work. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
   const userMsgCount = messages.filter(m => m.role === 'user').length;
   const hasExchanged = userMsgCount >= 2;
 

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -96,7 +96,8 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
       }
 
       const response = await chrome.runtime.sendMessage({ type: 'captureScreenshot' });
-      if (!response?.dataUrl) throw new Error('Screenshot capture failed.');
+      if (response?.error) throw new Error(response.error);
+      if (!response?.dataUrl) throw new Error('No screenshot data returned.');
 
       // Save screenshot to IndexedDB
       const screenshotKey = `onboarding-${Date.now()}`;
@@ -125,7 +126,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
       console.warn('Screenshot capture failed:', e);
       setMessages(prev => [...prev, {
         role: 'assistant',
-        content: JSON.stringify({ message: e.message || 'Capture failed. Try navigating to a webpage first, or just tell me about yourself.' })
+        content: JSON.stringify({ message: `Capture failed: ${e.message || 'Unknown error'}. Make sure you have a webpage open in the main browser window.` })
       }]);
       setCapturing(false);
     }

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -2,7 +2,8 @@ import { useState, useRef, useEffect } from 'react';
 import { useAuth } from '../../contexts/AuthContext.jsx';
 import { useAutoResize } from '../../hooks/useAutoResize.js';
 import { esc, renderMd } from '../../lib/helpers.js';
-import { saveLearnerProfile, saveLearnerProfileSummary } from '../../../js/storage.js';
+import { saveLearnerProfile, saveLearnerProfileSummary, saveScreenshot } from '../../../js/storage.js';
+import { MODEL_HEAVY } from '../../../js/api.js';
 import * as orchestrator from '../../../js/orchestrator.js';
 import { syncInBackground } from '../../lib/syncDebounce.js';
 import { ensureProfileExists, queueProfileUpdate } from '../../lib/profileQueue.js';
@@ -12,13 +13,14 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const [messages, setMessages] = useState(data.messages || []);
   const [profileDone, setProfileDone] = useState(data.profileDone || false);
   const [thinking, setThinking] = useState(false);
+  const [capturing, setCapturing] = useState(false);
   const [skipping, setSkipping] = useState(false);
   const [input, setInput] = useState('');
   const chatRef = useRef(null);
   const inputRef = useRef(null);
   const handleResize = useAutoResize();
 
-  const initialGreeting = `Hi, ${data.name}. What brings you here? What do you want to build, become, or achieve?`;
+  const initialGreeting = `Hi, ${data.name}! I'd love to get to know you through your work. Navigate to a page that represents you professionally — your LinkedIn, personal site, portfolio, a project, or even a social profile — and hit **Capture**. Or just tell me what you're working toward.`;
   const userMsgCount = messages.filter(m => m.role === 'user').length;
   const hasExchanged = userMsgCount >= 2;
 
@@ -32,21 +34,17 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
     updateData({ messages, profileDone });
   }, [messages, profileDone]);
 
-  const sendMessage = async () => {
-    const text = input.trim();
-    if (!text || thinking) return;
-    setInput('');
-    const newMessages = [...messages, { role: 'user', content: text }];
-    setMessages(newMessages);
+  /** Send the current message history to the agent and process the response. */
+  const callAgent = async (newMessages) => {
     setThinking(true);
-
     try {
       const msgs = newMessages.map((m, i) =>
-        i === 0 && m.role === 'user'
+        i === 0 && m.role === 'user' && typeof m.content === 'string'
           ? { role: 'user', content: `My name is ${data.name}. ${m.content}` }
           : m
       );
-      const result = await orchestrator.converse('onboarding-conversation', msgs, 1024);
+      // Use vision model since messages may contain screenshots
+      const result = await orchestrator.converse('onboarding-conversation', msgs, 1024, { model: MODEL_HEAVY });
 
       setMessages(prev => [...prev, { role: 'assistant', content: JSON.stringify(result) }]);
 
@@ -67,10 +65,77 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
     setThinking(false);
   };
 
+  /** Send a text message. */
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text || thinking || capturing) return;
+    setInput('');
+    const newMessages = [...messages, { role: 'user', content: text }];
+    setMessages(newMessages);
+    await callAgent(newMessages);
+  };
+
+  /** Capture a screenshot and send it as a message. */
+  const captureScreenshot = async () => {
+    if (thinking || capturing) return;
+    setCapturing(true);
+
+    try {
+      // Request permission if needed
+      const hasPermission = await chrome.permissions.contains({ origins: ['<all_urls>'] });
+      if (!hasPermission) {
+        const granted = await chrome.permissions.request({ origins: ['<all_urls>'] });
+        if (!granted) throw new Error('Permission needed to capture screenshots.');
+      }
+
+      const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      const pageUrl = tab?.url || '';
+      if (!pageUrl || pageUrl.startsWith('chrome://') || pageUrl.startsWith('about:')) {
+        throw new Error('Navigate to a webpage before capturing.');
+      }
+
+      const response = await chrome.runtime.sendMessage({ type: 'captureScreenshot' });
+      if (!response?.dataUrl) throw new Error('Screenshot capture failed.');
+
+      // Save screenshot to IndexedDB
+      const screenshotKey = `onboarding-${Date.now()}`;
+      await saveScreenshot(screenshotKey, response.dataUrl);
+
+      // Build a message with image content
+      const match = response.dataUrl.match(/^data:(image\/\w+);base64,(.+)$/);
+      const contentParts = [];
+      if (match) {
+        contentParts.push({
+          type: 'image',
+          source: { type: 'base64', media_type: match[1], data: match[2] }
+        });
+      }
+      contentParts.push({
+        type: 'text',
+        text: `[Screenshot captured from ${pageUrl}]`
+      });
+
+      const newMessages = [...messages, { role: 'user', content: contentParts, _screenshotKey: screenshotKey, _pageUrl: pageUrl }];
+      setMessages(newMessages);
+
+      setCapturing(false);
+      await callAgent(newMessages);
+    } catch (e) {
+      console.warn('Screenshot capture failed:', e);
+      setMessages(prev => [...prev, {
+        role: 'assistant',
+        content: JSON.stringify({ message: e.message || 'Capture failed. Try navigating to a webpage first, or just tell me about yourself.' })
+      }]);
+      setCapturing(false);
+    }
+  };
+
   const handleSkip = async () => {
-    // Save profile from whatever we have before navigating away
     if (!profileDone) {
-      const userText = messages.filter(m => m.role === 'user').map(m => m.content).join(' ');
+      const userText = messages
+        .filter(m => m.role === 'user')
+        .map(m => typeof m.content === 'string' ? m.content : '[screenshot]')
+        .join(' ');
       if (userText || data.name) {
         setSkipping(true);
         try {
@@ -94,29 +159,51 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
       const parsed = JSON.parse(msg.content);
       return parsed.message || msg.content;
     } catch {
-      return msg.content;
+      return typeof msg.content === 'string' ? msg.content : '';
     }
+  };
+
+  const renderUserMessage = (msg) => {
+    if (typeof msg.content === 'string') {
+      return <p dangerouslySetInnerHTML={{ __html: esc(msg.content) }} />;
+    }
+    // Content array (screenshot + text)
+    const textPart = msg.content?.find(p => p.type === 'text');
+    return (
+      <div>
+        <div style={{
+          display: 'inline-flex', alignItems: 'center', gap: '6px',
+          padding: '4px 8px', borderRadius: 'var(--radius)',
+          background: 'var(--color-surface-alt, #f0f0f0)', fontSize: '0.8rem',
+        }}>
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+          </svg>
+          {textPart?.text || 'Screenshot captured'}
+        </div>
+      </div>
+    );
   };
 
   return (
     <div className="onboarding" style={{ paddingBottom: 0 }}>
-      {!loggedIn && <span className="onboarding-step-label">Step 3 of 3 — About You</span>}
-      {loggedIn && <span className="onboarding-step-label">Tell us about yourself</span>}
+      {!loggedIn && <span className="onboarding-step-label">Step 3 of 3 — Show Your Work</span>}
+      {loggedIn && <span className="onboarding-step-label">Show us your work</span>}
 
       <div className="chat" role="log" aria-label="Getting to know you" ref={chatRef}>
         <div className="msg msg-response"><p dangerouslySetInnerHTML={{ __html: renderMd(initialGreeting) }} /></div>
         {messages.map((m, i) => (
           <div key={i} className={`msg ${m.role === 'user' ? 'msg-user' : 'msg-response'}`}>
-            <p dangerouslySetInnerHTML={{ __html: m.role === 'user' ? esc(m.content) : renderMd(parseMessage(m)) }} />
+            {m.role === 'user' ? renderUserMessage(m) : <p dangerouslySetInnerHTML={{ __html: renderMd(parseMessage(m)) }} />}
           </div>
         ))}
-        {thinking && (
+        {(thinking || capturing) && (
           <div className="msg msg-response" role="status" aria-live="polite">
             <span className="loading-spinner-inline" aria-hidden="true" />
-            <span>{messages.length <= 1 ? 'Getting to know you...' : 'Thinking...'}</span>
+            <span>{capturing ? 'Capturing...' : messages.length <= 1 ? 'Looking at your work...' : 'Thinking...'}</span>
           </div>
         )}
-        {hasExchanged && !profileDone && !thinking && (
+        {hasExchanged && !profileDone && !thinking && !capturing && (
           <button className="skip-step-btn" onClick={handleSkip} disabled={skipping}>
             {skipping ? 'Building your profile...' : 'Skip to courses'}
           </button>
@@ -134,25 +221,37 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
 
       <div className="chat-compose">
         <div className="compose-input-row">
+          <button
+            className="record-btn"
+            onClick={captureScreenshot}
+            disabled={thinking || capturing || skipping}
+            aria-label="Capture screenshot"
+            title="Capture current page"
+            style={{ flexShrink: 0, padding: '6px 10px' }}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>
+            </svg>
+          </button>
           <label htmlFor="onboarding-input" className="sr-only">Your response</label>
           <textarea
             ref={inputRef}
             id="onboarding-input"
             className="chat-input"
             rows={1}
-            placeholder={profileDone ? 'Say more or ask a question...' : 'I want to...'}
+            placeholder={profileDone ? 'Say more or ask a question...' : 'Or type a message...'}
             value={input}
             onChange={(e) => { setInput(e.target.value); handleResize(e); }}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); sendMessage(); }
             }}
-            disabled={thinking || skipping}
+            disabled={thinking || capturing || skipping}
           />
           <button
             className="send-btn"
             aria-label="Send"
             onClick={sendMessage}
-            disabled={thinking || skipping || !input.trim()}
+            disabled={thinking || capturing || skipping || !input.trim()}
           >
             <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
               <path d="M3 14V9l10-1L3 7V2l13 6z" />

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -227,6 +227,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
             disabled={thinking || capturing || skipping}
             aria-label="Capture screenshot"
             title="Capture current page"
+            style={{ height: 'auto', alignSelf: 'stretch' }}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/>

--- a/src/pages/onboarding/AboutYouStep.jsx
+++ b/src/pages/onboarding/AboutYouStep.jsx
@@ -21,7 +21,7 @@ export default function AboutYouStep({ data, updateData, onComplete }) {
   const handleResize = useAutoResize();
 
   const firstName = data.name?.split(' ')[0] || data.name;
-  const initialGreeting = `Hi, ${firstName}! I'd love to get to know you through your work. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
+  const initialGreeting = `Hi ${firstName} — let's see what you've got. Navigate to something that represents you professionally — LinkedIn, a portfolio, a project — and hit **Capture**.`;
   const userMsgCount = messages.filter(m => m.role === 'user').length;
   const hasExchanged = userMsgCount >= 2;
 

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -32,15 +32,7 @@ function queryAll(sql, params = []) {
   return rows;
 }
 
-// Mock db.js exports so storage.js picks them up
-const dbExports = { run, query, queryAll, persist: async () => {} };
-
-// Dynamic import with module mock — we inject our db functions
-// Since storage.js imports from './db.js', we use a loader trick:
-// We'll just re-implement the storage functions inline using our query API.
-// This tests the SQL logic directly.
-
-// -- Schema (copied from db.js) -----------------------------------------------
+// -- Schema (matches db.js) ---------------------------------------------------
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT);
@@ -48,26 +40,22 @@ CREATE TABLE IF NOT EXISTS preferences (id INTEGER PRIMARY KEY CHECK (id = 1), d
 CREATE TABLE IF NOT EXISTS profile (id INTEGER PRIMARY KEY CHECK (id = 1), data TEXT NOT NULL, updated_at INTEGER);
 CREATE TABLE IF NOT EXISTS profile_summary (id INTEGER PRIMARY KEY CHECK (id = 1), summary TEXT NOT NULL DEFAULT '', updated_at INTEGER);
 CREATE TABLE IF NOT EXISTS courses (course_id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, depends_on TEXT, is_user_created INTEGER DEFAULT 0, created_at INTEGER);
-CREATE TABLE IF NOT EXISTS units (unit_id TEXT PRIMARY KEY, course_id TEXT NOT NULL REFERENCES courses(course_id), name TEXT NOT NULL, description TEXT, depends_on TEXT, sequence INTEGER, status TEXT DEFAULT 'not_started', current_activity_index INTEGER DEFAULT 0, started_at INTEGER, completed_at INTEGER, final_work_product_url TEXT);
-CREATE TABLE IF NOT EXISTS learning_plans (unit_id TEXT PRIMARY KEY REFERENCES units(unit_id), final_work_product_description TEXT, work_product_tool TEXT, data TEXT, created_at INTEGER);
+CREATE TABLE IF NOT EXISTS units (unit_id TEXT PRIMARY KEY, course_id TEXT NOT NULL REFERENCES courses(course_id), name TEXT NOT NULL, description TEXT, depends_on TEXT, sequence INTEGER, status TEXT DEFAULT 'not_started', current_activity_index INTEGER DEFAULT 0, started_at INTEGER, completed_at INTEGER, final_work_product_url TEXT, journey_order INTEGER, rubric_criteria TEXT);
+CREATE TABLE IF NOT EXISTS summatives (course_id TEXT PRIMARY KEY, task TEXT NOT NULL, rubric TEXT NOT NULL, exemplar TEXT NOT NULL, tool TEXT, estimated_time INTEGER, personalized INTEGER DEFAULT 0, conversation_id TEXT, created_at INTEGER);
+CREATE TABLE IF NOT EXISTS summative_attempts (id TEXT PRIMARY KEY, course_id TEXT NOT NULL, attempt_number INTEGER NOT NULL, screenshots TEXT, criteria_scores TEXT, overall_score REAL, mastery INTEGER DEFAULT 0, feedback TEXT, next_steps TEXT, is_baseline INTEGER DEFAULT 0, timestamp INTEGER);
+CREATE INDEX IF NOT EXISTS idx_summative_attempts_course ON summative_attempts(course_id, attempt_number);
+CREATE TABLE IF NOT EXISTS gap_analysis (course_id TEXT PRIMARY KEY, gaps TEXT NOT NULL, suggested_focus TEXT, created_at INTEGER, updated_at INTEGER);
+CREATE TABLE IF NOT EXISTS journeys (course_id TEXT PRIMARY KEY, plan TEXT NOT NULL, phase TEXT DEFAULT 'summative_setup', created_at INTEGER, updated_at INTEGER);
 CREATE TABLE IF NOT EXISTS conversations (id TEXT PRIMARY KEY, unit_id TEXT REFERENCES units(unit_id), type TEXT NOT NULL, activity_id TEXT, created_at INTEGER);
 CREATE TABLE IF NOT EXISTS messages (id INTEGER PRIMARY KEY AUTOINCREMENT, conversation_id TEXT NOT NULL REFERENCES conversations(id), role TEXT NOT NULL, content TEXT NOT NULL, timestamp INTEGER NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_messages_conv ON messages(conversation_id, timestamp);
-CREATE TABLE IF NOT EXISTS activities (id TEXT PRIMARY KEY, unit_id TEXT NOT NULL REFERENCES units(unit_id), type TEXT NOT NULL, goal TEXT NOT NULL, instruction TEXT, tips TEXT, sequence INTEGER, conversation_id TEXT REFERENCES conversations(id));
-CREATE TABLE IF NOT EXISTS diagnostics (unit_id TEXT PRIMARY KEY REFERENCES units(unit_id), conversation_id TEXT REFERENCES conversations(id), instruction TEXT, score REAL, feedback TEXT, strengths TEXT, improvements TEXT, recommendation TEXT, passed INTEGER, skip_for TEXT);
-CREATE TABLE IF NOT EXISTS drafts (id TEXT PRIMARY KEY, activity_id TEXT NOT NULL REFERENCES activities(id), unit_id TEXT NOT NULL, screenshot_key TEXT, url TEXT, score REAL, feedback TEXT, strengths TEXT, improvements TEXT, recommendation TEXT, timestamp INTEGER);
+CREATE TABLE IF NOT EXISTS activities (id TEXT PRIMARY KEY, unit_id TEXT NOT NULL REFERENCES units(unit_id), type TEXT NOT NULL, goal TEXT NOT NULL, instruction TEXT, tips TEXT, sequence INTEGER, conversation_id TEXT REFERENCES conversations(id), rubric_criteria TEXT);
+CREATE TABLE IF NOT EXISTS drafts (id TEXT PRIMARY KEY, activity_id TEXT NOT NULL REFERENCES activities(id), unit_id TEXT NOT NULL, screenshot_key TEXT, url TEXT, score REAL, feedback TEXT, strengths TEXT, improvements TEXT, recommendation TEXT, timestamp INTEGER, rubric_criteria_scores TEXT);
 CREATE INDEX IF NOT EXISTS idx_drafts_activity ON drafts(activity_id);
 CREATE TABLE IF NOT EXISTS work_products (id INTEGER PRIMARY KEY AUTOINCREMENT, unit_id TEXT NOT NULL, course_name TEXT, url TEXT, completed_at INTEGER);
 CREATE TABLE IF NOT EXISTS auth (id INTEGER PRIMARY KEY CHECK (id = 1), access_token TEXT, refresh_token TEXT, user_json TEXT);
 CREATE TABLE IF NOT EXISTS pending_state (key TEXT PRIMARY KEY, state_json TEXT, updated_at INTEGER);
-CREATE TABLE IF NOT EXISTS dev_log (id INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT, data TEXT, timestamp INTEGER);
 `;
-
-// -- Inline storage functions (same SQL logic as storage.js) ------------------
-
-// We import storage.js but override the db dependency. Since that's hard with
-// static ESM, we instead test by calling the SQL directly — this validates
-// the schema and the query patterns that storage.js uses.
 
 beforeEach(async () => {
   if (!SQL) SQL = await initSqlJs();
@@ -85,6 +73,10 @@ describe('SQLite schema', () => {
     const names = tables.map(t => t.name);
     assert.ok(names.includes('settings'));
     assert.ok(names.includes('units'));
+    assert.ok(names.includes('summatives'));
+    assert.ok(names.includes('summative_attempts'));
+    assert.ok(names.includes('gap_analysis'));
+    assert.ok(names.includes('journeys'));
     assert.ok(names.includes('conversations'));
     assert.ok(names.includes('messages'));
     assert.ok(names.includes('activities'));
@@ -130,49 +122,20 @@ describe('profile', () => {
 describe('unit progress round-trip', () => {
   const unitId = 'foundations-0-basic-wordpress';
 
-  function saveUnitProgress(unitId, progress) {
+  function saveProgress(unitId, progress) {
     run('BEGIN TRANSACTION');
-    const courseId = 'foundations';
 
     run(
       `INSERT OR REPLACE INTO units
        (unit_id, course_id, name, description, sequence, status,
-        current_activity_index, started_at, completed_at, final_work_product_url)
-       VALUES (?, ?, '', '', 0, ?, ?, ?, ?, ?)`,
-      [unitId, courseId, progress.status, progress.currentActivityIndex || 0,
-       progress.startedAt || null, progress.completedAt || null, progress.finalWorkProductUrl || null]
+        current_activity_index, started_at, completed_at, final_work_product_url,
+        journey_order, rubric_criteria)
+       VALUES (?, ?, '', '', 0, ?, ?, ?, ?, ?, ?, ?)`,
+      [unitId, 'foundations', progress.status, progress.currentActivityIndex || 0,
+       progress.startedAt || null, progress.completedAt || null, progress.finalWorkProductUrl || null,
+       progress.journeyOrder ?? null,
+       progress.rubricCriteria ? JSON.stringify(progress.rubricCriteria) : null]
     );
-
-    if (progress.learningPlan) {
-      run(
-        `INSERT OR REPLACE INTO learning_plans (unit_id, final_work_product_description, work_product_tool, data, created_at)
-         VALUES (?, ?, ?, ?, ?)`,
-        [unitId, progress.learningPlan.finalWorkProductDescription, progress.learningPlan.workProductTool,
-         JSON.stringify(progress.learningPlan), Date.now()]
-      );
-    }
-
-    if (progress.diagnostic) {
-      const diagConvId = `diag-${unitId}`;
-      run('INSERT OR IGNORE INTO conversations (id, unit_id, type, created_at) VALUES (?, ?, ?, ?)',
-        [diagConvId, unitId, 'diagnostic', Date.now()]);
-      run('DELETE FROM messages WHERE conversation_id = ?', [diagConvId]);
-      for (const m of progress.diagnostic.messages || []) {
-        run('INSERT INTO messages (conversation_id, role, content, timestamp) VALUES (?, ?, ?, ?)',
-          [diagConvId, m.role, m.content, m.timestamp || Date.now()]);
-      }
-      const result = progress.diagnostic.result;
-      run(
-        `INSERT OR REPLACE INTO diagnostics
-         (unit_id, conversation_id, instruction, score, feedback, strengths, improvements, recommendation, passed)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-        [unitId, diagConvId, progress.diagnostic.instruction,
-         result?.score ?? null, result?.feedback || null,
-         result?.strengths ? JSON.stringify(result.strengths) : null,
-         result?.improvements ? JSON.stringify(result.improvements) : null,
-         result?.recommendation || null, result?.passed ? 1 : 0]
-      );
-    }
 
     const acts = progress.activities || [];
     for (let i = 0; i < acts.length; i++) {
@@ -187,63 +150,34 @@ describe('unit progress round-trip', () => {
           [convId, m.role, m.content, m.timestamp || Date.now()]);
       }
       run(
-        `INSERT OR REPLACE INTO activities (id, unit_id, type, goal, instruction, tips, sequence, conversation_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-        [actId, unitId, a.type, a.goal, a.instruction || null, a.tips || null, i, convId]
+        `INSERT OR REPLACE INTO activities (id, unit_id, type, goal, instruction, tips, sequence, conversation_id, rubric_criteria)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [actId, unitId, a.type, a.goal, a.instruction || null, a.tips || null, i, convId,
+         a.rubricCriteria ? JSON.stringify(a.rubricCriteria) : null]
       );
     }
 
     for (const d of progress.drafts || []) {
       run(
         `INSERT OR REPLACE INTO drafts
-         (id, activity_id, unit_id, screenshot_key, url, score, feedback, strengths, improvements, recommendation, timestamp)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         (id, activity_id, unit_id, screenshot_key, url, score, feedback,
+          strengths, improvements, recommendation, timestamp, rubric_criteria_scores)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [d.id, d.activityId, unitId, d.screenshotKey || null, d.url || null,
          d.score ?? null, d.feedback || null,
          d.strengths ? JSON.stringify(d.strengths) : null,
          d.improvements ? JSON.stringify(d.improvements) : null,
-         d.recommendation || null, d.timestamp || Date.now()]
+         d.recommendation || null, d.timestamp || Date.now(),
+         d.rubricCriteriaScores ? JSON.stringify(d.rubricCriteriaScores) : null]
       );
     }
 
     run('COMMIT');
   }
 
-  function getUnitProgress(unitId) {
+  function getProgress(unitId) {
     const unitRow = query('SELECT * FROM units WHERE unit_id = ?', [unitId]);
     if (!unitRow) return null;
-
-    const planRow = query('SELECT * FROM learning_plans WHERE unit_id = ?', [unitId]);
-    let learningPlan = null;
-    if (planRow) {
-      const planData = planRow.data ? JSON.parse(planRow.data) : null;
-      learningPlan = {
-        activities: planData?.activities || [],
-        finalWorkProductDescription: planRow.final_work_product_description,
-        workProductTool: planRow.work_product_tool,
-      };
-    }
-
-    const diagRow = query('SELECT * FROM diagnostics WHERE unit_id = ?', [unitId]);
-    let diagnostic = null;
-    if (diagRow) {
-      const diagMessages = diagRow.conversation_id
-        ? queryAll('SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY timestamp',
-            [diagRow.conversation_id])
-        : [];
-      diagnostic = {
-        instruction: diagRow.instruction,
-        messages: diagMessages.map(m => ({ role: m.role, content: m.content })),
-        result: diagRow.score != null ? {
-          score: diagRow.score,
-          feedback: diagRow.feedback,
-          strengths: diagRow.strengths ? JSON.parse(diagRow.strengths) : [],
-          improvements: diagRow.improvements ? JSON.parse(diagRow.improvements) : [],
-          recommendation: diagRow.recommendation,
-          passed: !!diagRow.passed,
-        } : null,
-      };
-    }
 
     const activityRows = queryAll('SELECT * FROM activities WHERE unit_id = ? ORDER BY sequence', [unitId]);
     const activities = activityRows.map(a => {
@@ -253,6 +187,7 @@ describe('unit progress round-trip', () => {
         : [];
       return {
         id: a.id, type: a.type, goal: a.goal, instruction: a.instruction, tips: a.tips,
+        rubricCriteria: a.rubric_criteria ? JSON.parse(a.rubric_criteria) : null,
         messages: msgs.map(m => ({ role: m.role, content: m.content, timestamp: m.timestamp })),
       };
     });
@@ -264,55 +199,37 @@ describe('unit progress round-trip', () => {
       strengths: d.strengths ? JSON.parse(d.strengths) : [],
       improvements: d.improvements ? JSON.parse(d.improvements) : [],
       score: d.score, recommendation: d.recommendation, timestamp: d.timestamp,
+      rubricCriteriaScores: d.rubric_criteria_scores ? JSON.parse(d.rubric_criteria_scores) : null,
     }));
 
     return {
-      unitId: unitRow.unit_id, status: unitRow.status,
-      currentActivityIndex: unitRow.current_activity_index,
-      diagnostic, learningPlan, activities, drafts,
+      unitId: unitRow.unit_id, courseId: unitRow.course_id,
+      status: unitRow.status, currentActivityIndex: unitRow.current_activity_index,
+      journeyOrder: unitRow.journey_order,
+      rubricCriteria: unitRow.rubric_criteria ? JSON.parse(unitRow.rubric_criteria) : null,
+      activities, drafts,
       startedAt: unitRow.started_at, completedAt: unitRow.completed_at,
       finalWorkProductUrl: unitRow.final_work_product_url,
     };
   }
 
   it('returns null for non-existent unit', () => {
-    assert.equal(getUnitProgress('no-such-unit'), null);
+    assert.equal(getProgress('no-such-unit'), null);
   });
 
   it('round-trips a full unit progress blob', () => {
     const now = Date.now();
     const progress = {
-      unitId,
       status: 'in_progress',
       currentActivityIndex: 1,
-      diagnostic: {
-        instruction: 'Tell me about your WordPress experience.',
-        messages: [
-          { role: 'assistant', content: 'What do you know about WordPress?', timestamp: now - 5000 },
-          { role: 'user', content: 'I have used it a bit.', timestamp: now - 4000 },
-        ],
-        result: {
-          score: 0.6,
-          feedback: 'Moderate familiarity',
-          strengths: ['basic navigation'],
-          improvements: ['theme customization'],
-          recommendation: 'continue',
-          passed: false,
-        },
-      },
-      learningPlan: {
-        activities: [
-          { id: 'a1', type: 'explore', goal: 'Explore the WP dashboard' },
-          { id: 'a2', type: 'apply', goal: 'Customize a theme' },
-        ],
-        finalWorkProductDescription: 'A customized WordPress page',
-        workProductTool: 'WordPress',
-      },
+      journeyOrder: 0,
+      rubricCriteria: ['Professional communication', 'Technical proficiency'],
       activities: [
         {
           id: 'a1', type: 'explore', goal: 'Explore the WP dashboard',
           instruction: 'Navigate to wp-admin and explore.',
           tips: 'Look at the sidebar menu.',
+          rubricCriteria: ['Technical proficiency'],
           messages: [
             { role: 'user', content: 'Where is the theme editor?', timestamp: now - 1000 },
             { role: 'assistant', content: 'Go to Appearance > Editor.', timestamp: now - 500 },
@@ -322,21 +239,18 @@ describe('unit progress round-trip', () => {
           id: 'a2', type: 'apply', goal: 'Customize a theme',
           instruction: 'Change the site title and colors.',
           tips: 'Use the Customizer.',
+          rubricCriteria: ['Professional communication', 'Technical proficiency'],
           messages: [],
         },
       ],
       drafts: [
         {
-          id: 'draft-1000',
-          activityId: 'a1',
+          id: 'draft-1000', activityId: 'a1',
           screenshotKey: 'activity-a1-draft-1000',
           url: 'https://example.com/wp-admin',
-          feedback: 'Good start',
-          strengths: ['found the menu'],
-          improvements: ['explore more'],
-          score: 0.7,
-          recommendation: 'advance',
-          timestamp: now,
+          feedback: 'Good start', strengths: ['found the menu'], improvements: ['explore more'],
+          score: 0.7, recommendation: 'advance', timestamp: now,
+          rubricCriteriaScores: [{ criterion: 'Technical proficiency', level: 'developing', score: 0.5 }],
         },
       ],
       startedAt: now - 10000,
@@ -344,31 +258,22 @@ describe('unit progress round-trip', () => {
       finalWorkProductUrl: null,
     };
 
-    saveUnitProgress(unitId, progress);
-    const loaded = getUnitProgress(unitId);
+    saveProgress(unitId, progress);
+    const loaded = getProgress(unitId);
 
     // Core fields
     assert.equal(loaded.unitId, unitId);
+    assert.equal(loaded.courseId, 'foundations');
     assert.equal(loaded.status, 'in_progress');
     assert.equal(loaded.currentActivityIndex, 1);
-    assert.equal(loaded.startedAt, now - 10000);
-    assert.equal(loaded.completedAt, null);
-
-    // Diagnostic
-    assert.equal(loaded.diagnostic.instruction, progress.diagnostic.instruction);
-    assert.equal(loaded.diagnostic.messages.length, 2);
-    assert.equal(loaded.diagnostic.messages[0].role, 'assistant');
-    assert.equal(loaded.diagnostic.result.score, 0.6);
-    assert.deepEqual(loaded.diagnostic.result.strengths, ['basic navigation']);
-
-    // Learning plan
-    assert.equal(loaded.learningPlan.activities.length, 2);
-    assert.equal(loaded.learningPlan.finalWorkProductDescription, 'A customized WordPress page');
+    assert.equal(loaded.journeyOrder, 0);
+    assert.deepEqual(loaded.rubricCriteria, ['Professional communication', 'Technical proficiency']);
 
     // Activities
     assert.equal(loaded.activities.length, 2);
     assert.equal(loaded.activities[0].id, 'a1');
     assert.equal(loaded.activities[0].instruction, 'Navigate to wp-admin and explore.');
+    assert.deepEqual(loaded.activities[0].rubricCriteria, ['Technical proficiency']);
     assert.equal(loaded.activities[0].messages.length, 2);
     assert.equal(loaded.activities[0].messages[1].content, 'Go to Appearance > Editor.');
     assert.equal(loaded.activities[1].messages.length, 0);
@@ -378,37 +283,120 @@ describe('unit progress round-trip', () => {
     assert.equal(loaded.drafts[0].activityId, 'a1');
     assert.equal(loaded.drafts[0].score, 0.7);
     assert.deepEqual(loaded.drafts[0].strengths, ['found the menu']);
-    assert.equal(loaded.drafts[0].screenshotKey, 'activity-a1-draft-1000');
+    assert.deepEqual(loaded.drafts[0].rubricCriteriaScores, [{ criterion: 'Technical proficiency', level: 'developing', score: 0.5 }]);
   });
 
   it('overwrites existing progress on re-save', () => {
-    saveUnitProgress(unitId, {
+    saveProgress(unitId, {
       status: 'in_progress', currentActivityIndex: 0,
-      learningPlan: null, diagnostic: null, activities: [], drafts: [],
+      activities: [], drafts: [],
       startedAt: 1000, completedAt: null, finalWorkProductUrl: null,
     });
 
-    saveUnitProgress(unitId, {
+    saveProgress(unitId, {
       status: 'completed', currentActivityIndex: 2,
-      learningPlan: null, diagnostic: null, activities: [], drafts: [],
+      activities: [], drafts: [],
       startedAt: 1000, completedAt: 2000, finalWorkProductUrl: 'https://example.com',
     });
 
-    const loaded = getUnitProgress(unitId);
+    const loaded = getProgress(unitId);
     assert.equal(loaded.status, 'completed');
     assert.equal(loaded.completedAt, 2000);
     assert.equal(loaded.finalWorkProductUrl, 'https://example.com');
   });
+});
 
-  it('handles progress with no diagnostic', () => {
-    saveUnitProgress(unitId, {
-      status: 'in_progress', currentActivityIndex: 0,
-      learningPlan: null, diagnostic: null, activities: [], drafts: [],
-      startedAt: 1000, completedAt: null, finalWorkProductUrl: null,
-    });
+describe('summatives', () => {
+  it('round-trips a summative', () => {
+    const courseId = 'foundations';
+    const summative = {
+      task: { steps: [{ instruction: 'Create a portfolio page' }] },
+      rubric: [{ name: 'Communication', levels: { beginning: 'x', developing: 'y', proficient: 'z', mastery: 'w' } }],
+      exemplar: 'A well-crafted portfolio page',
+      tool: 'Google Docs',
+      estimatedTime: 30,
+      personalized: false,
+    };
 
-    const loaded = getUnitProgress(unitId);
-    assert.equal(loaded.diagnostic, null);
+    run(
+      `INSERT INTO summatives (course_id, task, rubric, exemplar, tool, estimated_time, personalized, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [courseId, JSON.stringify(summative.task), JSON.stringify(summative.rubric),
+       summative.exemplar, summative.tool, summative.estimatedTime, 0, Date.now()]
+    );
+
+    const row = query('SELECT * FROM summatives WHERE course_id = ?', [courseId]);
+    assert.equal(row.course_id, courseId);
+    assert.deepEqual(JSON.parse(row.task), summative.task);
+    assert.deepEqual(JSON.parse(row.rubric), summative.rubric);
+    assert.equal(row.exemplar, summative.exemplar);
+    assert.equal(row.tool, 'Google Docs');
+  });
+});
+
+describe('summative attempts', () => {
+  it('stores and retrieves ordered attempts', () => {
+    const courseId = 'foundations';
+
+    run(
+      `INSERT INTO summative_attempts (id, course_id, attempt_number, screenshots, criteria_scores, overall_score, mastery, feedback, is_baseline, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['att-1', courseId, 1, JSON.stringify([{ screenshot_key: 's1', step_index: 0 }]),
+       JSON.stringify([{ criterion: 'Comm', level: 'developing', score: 0.5 }]),
+       0.5, 0, 'Good baseline', 1, 1000]
+    );
+
+    run(
+      `INSERT INTO summative_attempts (id, course_id, attempt_number, screenshots, criteria_scores, overall_score, mastery, feedback, is_baseline, timestamp)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['att-2', courseId, 2, JSON.stringify([{ screenshot_key: 's2', step_index: 0 }]),
+       JSON.stringify([{ criterion: 'Comm', level: 'proficient', score: 0.8 }]),
+       0.8, 1, 'Mastery achieved', 0, 2000]
+    );
+
+    const rows = queryAll('SELECT * FROM summative_attempts WHERE course_id = ? ORDER BY attempt_number', [courseId]);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].is_baseline, 1);
+    assert.equal(rows[1].mastery, 1);
+    assert.equal(rows[1].overall_score, 0.8);
+  });
+});
+
+describe('gap analysis', () => {
+  it('round-trips gap analysis', () => {
+    const courseId = 'foundations';
+    const gaps = [
+      { criterion: 'Technical proficiency', currentLevel: 'beginning', targetLevel: 'proficient', priority: 'high' },
+    ];
+
+    run(
+      'INSERT INTO gap_analysis (course_id, gaps, suggested_focus, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      [courseId, JSON.stringify(gaps), JSON.stringify(['tech skills']), Date.now(), Date.now()]
+    );
+
+    const row = query('SELECT * FROM gap_analysis WHERE course_id = ?', [courseId]);
+    assert.deepEqual(JSON.parse(row.gaps), gaps);
+    assert.deepEqual(JSON.parse(row.suggested_focus), ['tech skills']);
+  });
+});
+
+describe('journeys', () => {
+  it('round-trips a journey', () => {
+    const courseId = 'foundations';
+    const plan = {
+      units: [
+        { unitId: 'foundations-0-basic-wordpress', activities: [{ type: 'explore', goal: 'test' }] },
+      ],
+    };
+
+    run(
+      'INSERT INTO journeys (course_id, plan, phase, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      [courseId, JSON.stringify(plan), 'formative_learning', Date.now(), Date.now()]
+    );
+
+    const row = query('SELECT * FROM journeys WHERE course_id = ?', [courseId]);
+    assert.deepEqual(JSON.parse(row.plan), plan);
+    assert.equal(row.phase, 'formative_learning');
   });
 });
 
@@ -459,12 +447,12 @@ describe('auth (singleton)', () => {
 });
 
 describe('pending state', () => {
-  it('stores and retrieves diagnostic state', () => {
-    const state = { phase: 'activity', messages: [{ role: 'user', content: 'hi' }] };
-    run("INSERT OR REPLACE INTO pending_state (key, state_json, updated_at) VALUES ('diagnostic', ?, ?)",
-      [JSON.stringify(state), Date.now()]);
+  it('stores and retrieves rubric review state', () => {
+    const state = { messages: [{ role: 'user', content: 'Can the rubric include X?' }] };
+    run('INSERT OR REPLACE INTO pending_state (key, state_json, updated_at) VALUES (?, ?, ?)',
+      ['rubric-review:foundations', JSON.stringify(state), Date.now()]);
 
-    const row = query("SELECT state_json FROM pending_state WHERE key = 'diagnostic'");
+    const row = query("SELECT state_json FROM pending_state WHERE key = 'rubric-review:foundations'");
     assert.deepEqual(JSON.parse(row.state_json), state);
   });
 

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -43,19 +43,19 @@ function validSummative(overrides = {}) {
       {
         name: 'Professional communication',
         levels: {
-          beginning: 'No clear structure',
-          developing: 'Basic structure present',
-          proficient: 'Clear, professional structure',
-          mastery: 'Exceptional communication with consistent voice',
+          incomplete: 'No clear structure',
+          approaching: 'Basic structure present',
+          meets: 'Clear, professional structure',
+          exceeds: 'Exceptional communication with consistent voice',
         },
       },
       {
         name: 'Technical proficiency',
         levels: {
-          beginning: 'Unable to use the tool',
-          developing: 'Basic tool usage',
-          proficient: 'Effective tool usage',
-          mastery: 'Advanced tool usage with creative solutions',
+          incomplete: 'Unable to use the tool',
+          approaching: 'Basic tool usage',
+          meets: 'Effective tool usage',
+          exceeds: 'Advanced tool usage with creative solutions',
         },
       },
     ],
@@ -67,8 +67,8 @@ function validSummative(overrides = {}) {
 function validSummativeAssessment(overrides = {}) {
   return {
     criteriaScores: [
-      { criterion: 'Professional communication', level: 'proficient', score: 0.75, feedback: 'Good structure.' },
-      { criterion: 'Technical proficiency', level: 'developing', score: 0.5, feedback: 'Needs more practice.' },
+      { criterion: 'Professional communication', level: 'meets', score: 0.75, feedback: 'Good structure.' },
+      { criterion: 'Technical proficiency', level: 'approaching', score: 0.5, feedback: 'Needs more practice.' },
     ],
     overallScore: 0.625,
     mastery: false,
@@ -81,8 +81,8 @@ function validSummativeAssessment(overrides = {}) {
 function validGapAnalysis(overrides = {}) {
   return {
     gaps: [
-      { criterion: 'Technical proficiency', currentLevel: 'developing', targetLevel: 'proficient', priority: 'high' },
-      { criterion: 'Professional communication', currentLevel: 'proficient', targetLevel: 'mastery', priority: 'medium' },
+      { criterion: 'Technical proficiency', currentLevel: 'approaching', targetLevel: 'meets', priority: 'high' },
+      { criterion: 'Professional communication', currentLevel: 'meets', targetLevel: 'exceeds', priority: 'medium' },
     ],
     ...overrides,
   };
@@ -266,7 +266,7 @@ describe('validateSummative', () => {
 
   it('rejects rubric criterion missing a level', () => {
     const s = validSummative();
-    delete s.rubric[0].levels.mastery;
+    delete s.rubric[0].levels.exceeds;
     assert.ok(validateSummative(s));
   });
 

--- a/tests/validators.test.js
+++ b/tests/validators.test.js
@@ -3,9 +3,11 @@ import assert from 'node:assert/strict';
 import {
   validateSafety,
   validateActivity,
-  validateDiagnosticActivity,
   validateAssessment,
-  validatePlan,
+  validateSummative,
+  validateSummativeAssessment,
+  validateGapAnalysis,
+  validateJourney,
 } from '../js/validators.js';
 
 // -- Helpers ------------------------------------------------------------------
@@ -29,22 +31,74 @@ function validAssessment(overrides = {}) {
   };
 }
 
-function validPlan(activityCount, overrides = {}) {
-  const types = ['explore', 'apply', 'create', 'final'];
-  const activities = Array.from({ length: activityCount }, (_, i) => ({
-    type: i === activityCount - 1 ? 'final' : types[i % 3],
-    goal: `Objective ${i + 1}`,
-  }));
-  // Ensure no consecutive duplicates
-  for (let i = 1; i < activities.length - 1; i++) {
-    if (activities[i].type === activities[i - 1].type) {
-      activities[i].type = activities[i].type === 'explore' ? 'apply' : 'explore';
-    }
-  }
+function validSummative(overrides = {}) {
   return {
-    activities,
-    finalWorkProductDescription: 'A completed project',
-    workProductTool: 'WordPress',
+    task: {
+      steps: [
+        { instruction: 'Create a professional portfolio page in Google Docs.' },
+        { instruction: 'Add a header with your name and professional summary.' },
+      ],
+    },
+    rubric: [
+      {
+        name: 'Professional communication',
+        levels: {
+          beginning: 'No clear structure',
+          developing: 'Basic structure present',
+          proficient: 'Clear, professional structure',
+          mastery: 'Exceptional communication with consistent voice',
+        },
+      },
+      {
+        name: 'Technical proficiency',
+        levels: {
+          beginning: 'Unable to use the tool',
+          developing: 'Basic tool usage',
+          proficient: 'Effective tool usage',
+          mastery: 'Advanced tool usage with creative solutions',
+        },
+      },
+    ],
+    exemplar: 'A well-structured portfolio page with clear headings, professional summary, and organized sections.',
+    ...overrides,
+  };
+}
+
+function validSummativeAssessment(overrides = {}) {
+  return {
+    criteriaScores: [
+      { criterion: 'Professional communication', level: 'proficient', score: 0.75, feedback: 'Good structure.' },
+      { criterion: 'Technical proficiency', level: 'developing', score: 0.5, feedback: 'Needs more practice.' },
+    ],
+    overallScore: 0.625,
+    mastery: false,
+    feedback: 'Good progress, keep working on technical skills.',
+    nextSteps: ['Practice formatting', 'Review examples'],
+    ...overrides,
+  };
+}
+
+function validGapAnalysis(overrides = {}) {
+  return {
+    gaps: [
+      { criterion: 'Technical proficiency', currentLevel: 'developing', targetLevel: 'proficient', priority: 'high' },
+      { criterion: 'Professional communication', currentLevel: 'proficient', targetLevel: 'mastery', priority: 'medium' },
+    ],
+    ...overrides,
+  };
+}
+
+function validJourney(overrides = {}) {
+  return {
+    units: [
+      {
+        unitId: 'foundations-0-basic-wordpress',
+        activities: [
+          { type: 'explore', goal: 'Research portfolio layouts', rubricCriteria: ['Technical proficiency'] },
+          { type: 'create', goal: 'Build a draft portfolio', rubricCriteria: ['Professional communication', 'Technical proficiency'] },
+        ],
+      },
+    ],
     ...overrides,
   };
 }
@@ -60,34 +114,6 @@ describe('validateSafety', () => {
     assert.ok(validateSafety('how to hack a website'));
     assert.ok(validateSafety('kill yourself'));
     assert.ok(validateSafety('self-harm methods'));
-  });
-});
-
-// -- validateDiagnosticActivity -----------------------------------------------
-
-describe('validateDiagnosticActivity', () => {
-  it('accepts valid diagnostic activity', () => {
-    assert.equal(validateDiagnosticActivity({ instruction: 'Do the thing', tips: ['tip1'] }), null);
-  });
-
-  it('rejects missing instruction', () => {
-    assert.ok(validateDiagnosticActivity({ tips: ['tip1'] }));
-  });
-
-  it('rejects non-string instruction', () => {
-    assert.ok(validateDiagnosticActivity({ instruction: 123, tips: [] }));
-  });
-
-  it('rejects missing tips array', () => {
-    assert.ok(validateDiagnosticActivity({ instruction: 'Do it', tips: 'not an array' }));
-  });
-
-  it('rejects unsafe content in instruction', () => {
-    assert.ok(validateDiagnosticActivity({ instruction: 'how to hack a server', tips: [] }));
-  });
-
-  it('rejects unsafe content in tips', () => {
-    assert.ok(validateDiagnosticActivity({ instruction: 'Do the thing', tips: ['kill yourself'] }));
   });
 });
 
@@ -207,52 +233,182 @@ describe('validateAssessment', () => {
   });
 });
 
-// -- validatePlan -------------------------------------------------------------
+// -- validateSummative --------------------------------------------------------
 
-describe('validatePlan', () => {
-  it('accepts a valid plan', () => {
-    assert.equal(validatePlan(validPlan(3), 3), null);
+describe('validateSummative', () => {
+  it('accepts a valid summative', () => {
+    assert.equal(validateSummative(validSummative()), null);
   });
 
-  it('rejects wrong activity count', () => {
-    assert.ok(validatePlan(validPlan(3), 4));
+  it('rejects missing task', () => {
+    assert.ok(validateSummative(validSummative({ task: null })));
   });
 
-  it('rejects missing activities array', () => {
-    assert.ok(validatePlan({ finalWorkProductDescription: 'x', workProductTool: 'y' }, 1));
+  it('rejects task with empty steps', () => {
+    assert.ok(validateSummative(validSummative({ task: { steps: [] } })));
   });
 
-  it('rejects missing finalWorkProductDescription', () => {
-    const plan = validPlan(2);
-    delete plan.finalWorkProductDescription;
-    assert.ok(validatePlan(plan, 2));
+  it('rejects step missing instruction', () => {
+    assert.ok(validateSummative(validSummative({
+      task: { steps: [{ instruction: 'Good' }, {}] },
+    })));
   });
 
-  it('rejects missing workProductTool', () => {
-    const plan = validPlan(2);
-    delete plan.workProductTool;
-    assert.ok(validatePlan(plan, 2));
+  it('rejects empty rubric', () => {
+    assert.ok(validateSummative(validSummative({ rubric: [] })));
   });
 
-  it('rejects plan where last activity is not type final', () => {
-    const plan = validPlan(3);
-    plan.activities[2].type = 'explore';
-    assert.ok(validatePlan(plan, 3));
+  it('rejects rubric criterion missing name', () => {
+    const s = validSummative();
+    s.rubric[0].name = '';
+    assert.ok(validateSummative(s));
   });
 
-  it('rejects consecutive duplicate activity types', () => {
-    const plan = validPlan(4);
-    plan.activities[0].type = 'explore';
-    plan.activities[1].type = 'explore';
-    assert.ok(validatePlan(plan, 4));
+  it('rejects rubric criterion missing a level', () => {
+    const s = validSummative();
+    delete s.rubric[0].levels.mastery;
+    assert.ok(validateSummative(s));
   });
 
-  it('accepts single-activity plan with type final', () => {
-    const plan = {
-      activities: [{ type: 'final', goal: 'Do the thing' }],
-      finalWorkProductDescription: 'A thing',
-      workProductTool: 'Browser',
+  it('rejects missing exemplar', () => {
+    assert.ok(validateSummative(validSummative({ exemplar: '' })));
+  });
+
+  it('rejects unsafe content in exemplar', () => {
+    assert.ok(validateSummative(validSummative({ exemplar: 'how to hack a database' })));
+  });
+});
+
+// -- validateSummativeAssessment ----------------------------------------------
+
+describe('validateSummativeAssessment', () => {
+  it('accepts a valid summative assessment', () => {
+    assert.equal(validateSummativeAssessment(validSummativeAssessment()), null);
+  });
+
+  it('rejects empty criteriaScores', () => {
+    assert.ok(validateSummativeAssessment(validSummativeAssessment({ criteriaScores: [] })));
+  });
+
+  it('rejects criterion with invalid level', () => {
+    const a = validSummativeAssessment();
+    a.criteriaScores[0].level = 'expert';
+    assert.ok(validateSummativeAssessment(a));
+  });
+
+  it('rejects criterion score out of range', () => {
+    const a = validSummativeAssessment();
+    a.criteriaScores[0].score = 1.5;
+    assert.ok(validateSummativeAssessment(a));
+  });
+
+  it('rejects overallScore out of range', () => {
+    assert.ok(validateSummativeAssessment(validSummativeAssessment({ overallScore: -0.1 })));
+  });
+
+  it('rejects non-boolean mastery', () => {
+    assert.ok(validateSummativeAssessment(validSummativeAssessment({ mastery: 1 })));
+  });
+
+  it('rejects missing feedback', () => {
+    assert.ok(validateSummativeAssessment(validSummativeAssessment({ feedback: '' })));
+  });
+
+  it('enforces ratchet rule — rejects lower score than prior attempt', () => {
+    const priorAttempt = {
+      criteriaScores: [
+        { criterion: 'Professional communication', score: 0.8 },
+        { criterion: 'Technical proficiency', score: 0.5 },
+      ],
     };
-    assert.equal(validatePlan(plan, 1), null);
+    const current = validSummativeAssessment();
+    current.criteriaScores[0].score = 0.7; // lower than prior 0.8
+    assert.ok(validateSummativeAssessment(current, priorAttempt));
+  });
+
+  it('allows equal or higher scores with prior attempt', () => {
+    const priorAttempt = {
+      criteriaScores: [
+        { criterion: 'Professional communication', score: 0.7 },
+        { criterion: 'Technical proficiency', score: 0.4 },
+      ],
+    };
+    assert.equal(validateSummativeAssessment(validSummativeAssessment(), priorAttempt), null);
+  });
+
+  it('passes with no prior attempt', () => {
+    assert.equal(validateSummativeAssessment(validSummativeAssessment(), null), null);
+  });
+});
+
+// -- validateGapAnalysis ------------------------------------------------------
+
+describe('validateGapAnalysis', () => {
+  it('accepts a valid gap analysis', () => {
+    assert.equal(validateGapAnalysis(validGapAnalysis()), null);
+  });
+
+  it('rejects empty gaps', () => {
+    assert.ok(validateGapAnalysis({ gaps: [] }));
+  });
+
+  it('rejects gap missing criterion', () => {
+    const g = validGapAnalysis();
+    g.gaps[0].criterion = '';
+    assert.ok(validateGapAnalysis(g));
+  });
+
+  it('rejects invalid currentLevel', () => {
+    const g = validGapAnalysis();
+    g.gaps[0].currentLevel = 'expert';
+    assert.ok(validateGapAnalysis(g));
+  });
+
+  it('rejects invalid priority', () => {
+    const g = validGapAnalysis();
+    g.gaps[0].priority = 'critical';
+    assert.ok(validateGapAnalysis(g));
+  });
+});
+
+// -- validateJourney ----------------------------------------------------------
+
+describe('validateJourney', () => {
+  it('accepts a valid journey', () => {
+    assert.equal(validateJourney(validJourney()), null);
+  });
+
+  it('rejects empty units', () => {
+    assert.ok(validateJourney({ units: [] }));
+  });
+
+  it('rejects unit missing unitId', () => {
+    const j = validJourney();
+    j.units[0].unitId = '';
+    assert.ok(validateJourney(j));
+  });
+
+  it('rejects unit with no activities', () => {
+    const j = validJourney();
+    j.units[0].activities = [];
+    assert.ok(validateJourney(j));
+  });
+
+  it('rejects activity missing type', () => {
+    const j = validJourney();
+    delete j.units[0].activities[0].type;
+    assert.ok(validateJourney(j));
+  });
+
+  it('rejects activity missing goal', () => {
+    const j = validJourney();
+    delete j.units[0].activities[0].goal;
+    assert.ok(validateJourney(j));
+  });
+
+  it('rejects activity with empty rubricCriteria', () => {
+    const j = validJourney();
+    j.units[0].activities[0].rubricCriteria = [];
+    assert.ok(validateJourney(j));
   });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
         { src: 'prompts', dest: '' },
         { src: 'assets', dest: '' },
         { src: 'js', dest: '' },
+        { src: '.env.js', dest: '', rename: '.env.js' },
       ],
     }),
   ],


### PR DESCRIPTION
## Summary

Replaces the diagnostic-first, unit-centric flow with an assessment-backward, course-centric design. A summative assessment (rubric + exemplar + multi-step capture task) is generated from all course learning objectives. The learner takes it as a diagnostic baseline, gap analysis drives personalized formative activities, and the learner retakes the summative to demonstrate mastery.

**Core changes:**
- **Schema**: Replaced `diagnostics`/`learning_plans` tables with `summatives`, `summative_attempts`, `gap_analysis`, `journeys`. Added rubric criteria columns to units/activities/drafts.
- **Agents**: 3 prompts replaced (rubric review, summative assessment, journey generation), 2 new (summative generation, gap analysis), 5 modified for rubric context and direct tone.
- **Orchestrator**: Added `generateSummative`, `assessSummativeAttempt` (multi-capture vision), `analyzeGaps`, `generateJourney`. Auto-retries on 503/500. Removed diagnostic text assessment.
- **Engine**: Course-level lifecycle (summative → gap → journey → formatives → retake). Simplified unit-level (no diagnostic, activities from journey plan).
- **UI**: UnitsList is now the course hub with step-by-step summative flow. UnitChat simplified for formatives. Portfolio refactored to course-level. Staggered message reveals. Course reset button.
- **Onboarding**: Capture-based portfolio review replaces text-only conversation. Vision model analyzes screenshots.
- **Assessment labels**: Exceeds / Meets / Approaching / Incomplete (no percentages shown to learners).
- **Error handling**: `[1111]` prefixed logging, actual errors surfaced to UI, transient API retry.
- **Validators**: New summative/gap/journey validators with ratchet rule enforcement.
- **Sync**: New sync keys for summative/gap/journey data.
- **Docs**: CLAUDE.md and CONTRIBUTING.md updated.

## Test plan
- [x] `npm test` — 86 tests pass
- [x] `vite build` — clean build
- [x] Manual: onboarding capture flow with portfolio screenshots
- [x] Manual: summative generation → baseline attempt → gap analysis → journey
- [x] Manual: formative activities in unit chat
- [x] Manual: summative retake → mastery or remediation loop
- [x] Manual: course reset from header
- [x] Manual: portfolio view shows course-level data

🤖 Generated with [Claude Code](https://claude.com/claude-code)