### PR TITLE
Fix iOS Safari headers, simplify nav, enable course sync

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -16,15 +16,19 @@ import {
   getDrafts, saveDraft, deleteDraftsForCourse,
   getCourseMessages, saveCourseMessages, clearCourseMessages,
   getScreenshot, saveScreenshot,
+  getUserCourseMarkdown, saveUserCourse, deleteUserCourse,
   deleteProfile, deleteProfileSummary, deletePreferences,
 } from './storage.js';
 
 const _versions = {};
 
-// Keys the server currently accepts. New keys (activities, activityKBs, messages,
-// courseKB, onboardingComplete) are stored locally and will sync once learn-service
-// is updated. Until then, skip them to avoid 400 console noise.
-const SERVER_KNOWN_PREFIXES = ['profile', 'profileSummary', 'preferences', 'summative', 'gap', 'journey', 'progress'];
+// Keys the server accepts for sync.
+const SERVER_KNOWN_PREFIXES = [
+  'profile', 'profileSummary', 'preferences',
+  'summative', 'gap', 'journey', 'progress',
+  'courseKB', 'activities', 'activityKBs', 'drafts', 'messages',
+  'courses', 'onboardingComplete',
+];
 
 function serverAcceptsKey(syncKey) {
   return SERVER_KNOWN_PREFIXES.some(p => syncKey === p || syncKey.startsWith(p + ':'));
@@ -123,6 +127,7 @@ async function getLocalData(syncKey) {
     );
   }
   if (syncKey.startsWith('messages:')) return getCourseMessages(syncKey.slice('messages:'.length));
+  if (syncKey.startsWith('courses:')) return getUserCourseMarkdown(syncKey.slice('courses:'.length));
   return null;
 }
 
@@ -165,6 +170,15 @@ async function saveLocalData(syncKey, data) {
     const courseId = syncKey.slice('messages:'.length);
     await clearCourseMessages(courseId);
     await saveCourseMessages(courseId, Array.isArray(data) ? data : [data]);
+    return;
+  }
+  if (syncKey.startsWith('courses:')) {
+    const courseId = syncKey.slice('courses:'.length);
+    if (data) {
+      await saveUserCourse(courseId, data);
+    } else {
+      await deleteUserCourse(courseId);
+    }
     return;
   }
 }


### PR DESCRIPTION
## Summary
- Fix blue heading text on iOS Safari by adding explicit `color: var(--color-text)` to all heading levels
- Remove mobile bottom navigation bar; make the header logo/title link to courses; move Settings into the user dropdown (logged in) or inline next to Login (logged out); truncate long emails in the header
- Enable cloud sync for all course data (messages, KBs, activities, drafts, user-created courses) so course progress persists across login/logout cycles

## Test plan
- [ ] Verify headings on iOS Safari render with correct text color (not blue)
- [ ] Verify tapping the 1111 Learn logo/text navigates to courses list
- [ ] Verify Settings is accessible from the user dropdown when logged in
- [ ] Verify Settings button appears next to Login when logged out
- [ ] Verify long emails truncate with ellipsis in the header
- [ ] Verify no bottom nav bar appears on mobile
- [ ] Log in, start/progress through a course, log out, log back in — course progress should be restored

https://claude.ai/code/session_01NPFshj6KCgEjhJt3JYE47m